### PR TITLE
SurfaceMatching: OpenMP indices

### DIFF
--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -375,7 +375,7 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr> poseList, int numPoses, 
 #pragma omp parallel for
 #endif
     // uses weighting by the number of votes
-    for (size_t i=0; i<poseClusters.size(); i++)
+    for (int i=0; i<static_cast<int>(poseClusters.size()); i++)
     {
       // We could only average the quaternions. So I will make use of them here
       double qAvg[4]={0}, tAvg[3]={0};
@@ -426,7 +426,7 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr> poseList, int numPoses, 
 #if defined _OPENMP
 #pragma omp parallel for
 #endif
-    for (size_t i=0; i<poseClusters.size(); i++)
+    for (int i=0; i<static_cast<int>(poseClusters.size()); i++)
     {
       // We could only average the quaternions. So I will make use of them here
       double qAvg[4]={0}, tAvg[3]={0};


### PR DESCRIPTION
Fixes compiler error: "index variable in OpenMP 'for' statement must have signed integral type"