### PR TITLE
line_descriptor module fix vs2013 build

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -756,7 +756,7 @@ int BinaryDescriptor::OctaveKeyLines( cv::Mat& image, ScaleLines &keyLines )
 
   /* some variables' declarations */
   float rho1, rho2, tempValue;
-  float direction, near, length;
+  float direction, diffNear, length;
   unsigned int octaveID, lineIDInOctave;
 
   /*more than one octave image, organize lines in scale space.
@@ -784,8 +784,8 @@ int BinaryDescriptor::OctaveKeyLines( cv::Mat& image, ScaleLines &keyLines )
         /*nearThreshold depends on the distance of the image coordinate origin to current line.
          *so nearThreshold = rho1 * nearThresholdRatio, where nearThresholdRatio = 1-cos(10*pi/180) = 0.0152*/
         tempValue = (float) ( rho1 * 0.0152 );
-        float nearThreshold = ( tempValue > 6 ) ? ( tempValue ) : 6;
-        nearThreshold = ( nearThreshold < 12 ) ? nearThreshold : 12;
+        float diffNearThreshold = ( tempValue > 6 ) ? ( tempValue ) : 6;
+        diffNearThreshold = ( diffNearThreshold < 12 ) ? diffNearThreshold : 12;
 
         /* compute scaled lenght of current line */
         dx = fabs( edLineVec_[octaveCount]->lineEndpoints_[lineCurId][0] - edLineVec_[octaveCount]->lineEndpoints_[lineCurId][2] );  //x1-x2
@@ -831,10 +831,10 @@ int BinaryDescriptor::OctaveKeyLines( cv::Mat& image, ScaleLines &keyLines )
           /* get known term from equation to be compared */
           rho2 = (float) ( scale[octaveID] * fabs( edLineVec_[octaveID]->lineEquations_[lineIDInOctave][2] ) );
           /* compute difference between known ters */
-          near = fabs( rho1 - rho2 );
+          diffNear = fabs( rho1 - rho2 );
 
           /* two lines are not close in the image */
-          if( near > nearThreshold )
+          if( diffNear > diffNearThreshold )
           {
             continue;
           }


### PR DESCRIPTION
Could not compile binary_descriptor.cpp due to a variable 'near' which is defined in
"Windows Kits\8.1\Include\shared\minwindef.h:95"

```
#define near
```

Using Visual Studio 2013, found the same file and line in Windows Kit 8.0 for VS 2012 so it would probably fail there too due to this bug

renamed threshold variable since this belongs together

edit: tested with 2012, same error there