### PR TITLE
[fix issue #3996] delete private.hpp include in sample code

### DIFF
--- a/modules/line_descriptor/samples/compute_descriptors.cpp
+++ b/modules/line_descriptor/samples/compute_descriptors.cpp
@@ -42,7 +42,6 @@
 #include <opencv2/line_descriptor.hpp>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>

--- a/modules/line_descriptor/samples/knn_matching.cpp
+++ b/modules/line_descriptor/samples/knn_matching.cpp
@@ -42,7 +42,6 @@
 #include <opencv2/line_descriptor.hpp>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>

--- a/modules/line_descriptor/samples/lines_extraction.cpp
+++ b/modules/line_descriptor/samples/lines_extraction.cpp
@@ -42,7 +42,6 @@
 #include <opencv2/line_descriptor.hpp>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>

--- a/modules/line_descriptor/samples/lsd_lines_extraction.cpp
+++ b/modules/line_descriptor/samples/lsd_lines_extraction.cpp
@@ -42,7 +42,6 @@
 #include <opencv2/line_descriptor.hpp>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>

--- a/modules/line_descriptor/samples/matching.cpp
+++ b/modules/line_descriptor/samples/matching.cpp
@@ -42,7 +42,6 @@
 #include <opencv2/line_descriptor.hpp>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>

--- a/modules/line_descriptor/samples/radius_matching.cpp
+++ b/modules/line_descriptor/samples/radius_matching.cpp
@@ -42,7 +42,6 @@
 #include <opencv2/line_descriptor.hpp>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>


### PR DESCRIPTION
Bug described here:
http://code.opencv.org/issues/3996

private.hpp should not be included in noninternal opencv code.
Removing is safe, compiled fine for me.