### PR TITLE
fix issue for vs versions which aren't standarized for the c99 standard

### DIFF
--- a/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp
+++ b/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp
@@ -45,7 +45,13 @@
 #include <map>
 #include <vector>
 #include <list>
+
+#if defined _MSC_VER && _MSC_VER <= 1700
+#include <stdint.h>
+#else
 #include <inttypes.h>
+#endif
+
 #include <stdio.h>
 #include <iostream>
 

--- a/modules/line_descriptor/src/types.hpp
+++ b/modules/line_descriptor/src/types.hpp
@@ -40,7 +40,11 @@
  //
  //M*/
 
+#if defined _MSC_VER && _MSC_VER <= 1700
+#include <stdint.h>
+#else
 #include <inttypes.h>
+#endif
 
 #ifndef __OPENCV_TYPES_HPP
 #define __OPENCV_TYPES_HPP


### PR DESCRIPTION
Reported and investigated in #125 
A developer has to say if this is the correct way to handle this in general.

fixes compilation error for vs2012, 2010, 2008, 2005 and maybe even prior versions

edited: also needed for vs2012