### PR TITLE
Disable some modules for iOS framework world build

### DIFF
--- a/modules/adas/CMakeLists.txt
+++ b/modules/adas/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(IOS)
+    ocv_module_disable(adas)
+endif()
+
 set(the_description "Automatic driver assistance algorithms")
 ocv_define_module(adas opencv_xobjdetect)
 

--- a/modules/saliency/CMakeLists.txt
+++ b/modules/saliency/CMakeLists.txt
@@ -1,2 +1,3 @@
 set(the_description "Saliency API")
+set(OPENCV_MODULE_IS_PART_OF_WORLD OFF)
 ocv_define_module(saliency opencv_imgproc opencv_highgui opencv_features2d)

--- a/modules/ximgproc/CMakeLists.txt
+++ b/modules/ximgproc/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(the_description "Extended image processing module. It includes edge-aware filters and etc.")
+set(OPENCV_MODULE_IS_PART_OF_WORLD OFF)
 ocv_define_module(ximgproc opencv_imgproc opencv_core opencv_highgui)
 
 target_link_libraries(opencv_ximgproc)


### PR DESCRIPTION
adas, saliency and ximgproc modules causes build errors for iOS contrib framework