### PR TITLE
Fixes required to compile MATLAB bindings

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -104,6 +104,7 @@ set(HDR_PARSER_PATH ${CMAKE_SOURCE_DIR}/modules/python/src2)
 set(RST_PARSER_PATH ${CMAKE_SOURCE_DIR}/modules/java/generator)
 
 # set mex compiler options
+prepend("-I" MEX_INCLUDE_DIRS ${CMAKE_BINARY_DIR})
 prepend("-I" MEX_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
 if (MSVC)
     prepend("-L" MEX_LIB_DIR  ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})

--- a/modules/matlab/include/opencv2/matlab/bridge.hpp
+++ b/modules/matlab/include/opencv2/matlab/bridge.hpp
@@ -53,6 +53,7 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/calib3d.hpp>
 #include <opencv2/photo.hpp>
+#include <opencv2/stitching.hpp>
 #include <opencv2/video.hpp>
 
 namespace cv {
@@ -87,6 +88,7 @@ typedef cv::Ptr<DenseOpticalFlow> Ptr_DenseOpticalFlow;
 typedef cv::Ptr<MergeDebevec> Ptr_MergeDebevec;
 typedef cv::Ptr<MergeMertens> Ptr_MergeMertens;
 typedef cv::Ptr<MergeRobertson> Ptr_MergeRobertson;
+typedef cv::Ptr<Stitcher> Ptr_Stitcher;
 typedef cv::Ptr<Tonemap> Ptr_Tonemap;
 typedef cv::Ptr<TonemapDrago> Ptr_TonemapDrago;
 typedef cv::Ptr<TonemapDurand> Ptr_TonemapDurand;
@@ -480,6 +482,11 @@ public:
   Bridge& operator=(const Ptr_MergeRobertson& ) { return *this; }
   Ptr_MergeRobertson toPtrMergeRobertson() { return Ptr_MergeRobertson(); }
   operator Ptr_MergeRobertson() { return toPtrMergeRobertson(); }
+
+  // ---------------------------   Ptr_Stitcher   ------------------------------
+  Bridge& operator=(const Ptr_Stitcher& ) { return *this; }
+  Ptr_Stitcher toPtrStitcher() { return Ptr_Stitcher(); }
+  operator Ptr_Stitcher() { return toPtrStitcher(); }
 
   // ---------------------------   Ptr_Tonemap   ------------------------------
   Bridge& operator=(const Ptr_Tonemap& ) { return *this; }


### PR DESCRIPTION
The following fixes were required to compile MATLAB bindings under linux with MATLAB R2014b.