### PR TITLE
Fix for Bug 4074. Both conditions of if are same

### DIFF
--- a/modules/text/src/ocr_tesseract.cpp
+++ b/modules/text/src/ocr_tesseract.cpp
@@ -59,7 +59,7 @@ void OCRTesseract::run(Mat& image, string& output_text, vector<Rect>* component_
                        vector<string>* component_texts, vector<float>* component_confidences,
                        int component_level)
 {
-    CV_Assert( (image.type() == CV_8UC1) || (image.type() == CV_8UC1) );
+    CV_Assert( (image.type() == CV_8UC1) || (image.type() == CV_8UC3) );
     CV_Assert( (component_level == OCR_LEVEL_TEXTLINE) || (component_level == OCR_LEVEL_WORD) );
     output_text.clear();
     if (component_rects != NULL)


### PR DESCRIPTION
The docs specify it to allow 8UC1 and 8UC3 images.