### PR TITLE
Fix typo in ERFilter

### DIFF
--- a/modules/text/doc/erfilter.rst
+++ b/modules/text/doc/erfilter.rst
@@ -160,7 +160,7 @@ The key method of ERFilter algorithm. Takes image on input and returns the selec
 
 .. ocv:function:: void ERFilter::run( InputArray image, std::vector<ERStat>& regions )
 
-    :param image: Sinle channel image ``CV_8UC1``
+    :param image: Single channel image ``CV_8UC1``
     :param regions: Output for the 1st stage and Input/Output for the 2nd. The selected Extremal Regions are stored here.
 
 Extracts the component tree (if needed) and filter the extremal regions (ER's) by using a given classifier.

--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -140,7 +140,7 @@ public:
     Takes image on input and returns the selected regions in a vector of ERStat only distinctive
     ERs which correspond to characters are selected by a sequential classifier
 
-    @param image Sinle channel image CV_8UC1
+    @param image Single channel image CV_8UC1
 
     @param regions Output for the 1st stage and Input/Output for the 2nd. The selected Extremal Regions
     are stored here.


### PR DESCRIPTION
Noticed in http://docs.opencv.org/trunk/modules/text/doc/erfilter.html that "single" has been written as "sinle" instead. Fixed it at both locations found in the repo.