### PR TITLE
Function cuda::integral() does not require an extra buffer any more.

### DIFF
--- a/modules/xfeatures2d/include/opencv2/xfeatures2d/cuda.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d/cuda.hpp
@@ -152,7 +152,7 @@ public:
     //! max keypoints = min(keypointsRatio * img.size().area(), 65535)
     float keypointsRatio;
 
-    GpuMat sum, mask1, maskSum, intBuffer;
+    GpuMat sum, mask1, maskSum;
 
     GpuMat det, trace;
 

--- a/modules/xfeatures2d/src/surf.cuda.cpp
+++ b/modules/xfeatures2d/src/surf.cuda.cpp
@@ -146,13 +146,13 @@ namespace
 
             bindImgTex(img);
 
-            cuda::integral(img, surf_.sum, surf_.intBuffer);
+            cuda::integral(img, surf_.sum);
             sumOffset = bindSumTex(surf_.sum);
 
             if (use_mask)
             {
                 cuda::min(mask, 1.0, surf_.mask1);
-                cuda::integral(surf_.mask1, surf_.maskSum, surf_.intBuffer);
+                cuda::integral(surf_.mask1, surf_.maskSum);
                 maskOffset = bindMaskSumTex(surf_.maskSum);
             }
         }
@@ -425,7 +425,6 @@ void cv::cuda::SURF_CUDA::releaseMemory()
     sum.release();
     mask1.release();
     maskSum.release();
-    intBuffer.release();
     det.release();
     trace.release();
     maxPosBuffer.release();


### PR DESCRIPTION
This fix is required to successfully compile against the current OpenCV HEAD.