### PR TITLE
Bug fix #1

### DIFF
--- a/modules/tracking/src/tld_utils.cpp
+++ b/modules/tracking/src/tld_utils.cpp
@@ -359,8 +359,8 @@ int TLDEnsembleClassifier::code(const uchar* data, int rowstep) const
     for( int i = 0; i < (int)measurements.size(); i++ )
     {
         position = position << 1;
-        if( *(data + rowstep * measurements[i].val[0] + measurements[i].val[1]) <
-                *(data + rowstep * measurements[i].val[2] + measurements[i].val[3]) )
+        if( *(data + rowstep * measurements[i].val[2] + measurements[i].val[0]) <
+                *(data + rowstep * measurements[i].val[3] + measurements[i].val[1]) )
         {
             position++;
         }


### PR DESCRIPTION
The bug appears on the initialization step, if the initial bounding box width was larger than height. The problem was in function calculating a binary code for ensemble classifiers. In this function “measurement” values were used in wrong order (h1,w1,h2,w2; instead of: w1,w2,h1,h2), generating a access violation error on “patch” data access by the reason that width>height and pointer to data is calculated linearly data.step*height+width