### PR TITLE
corrected the testing data path for latentsvm detector and some typos

### DIFF
--- a/modules/latentsvm/src/_lsvmc_function.h
+++ b/modules/latentsvm/src/_lsvmc_function.h
@@ -49,10 +49,10 @@ namespace cv
 namespace lsvm
 {
 
-float calcM         (int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, const CvLSVMFilterObjectCaskade *filter);
-float calcM_PCA     (int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, const CvLSVMFilterObjectCaskade *filter);
-float calcM_PCA_cash(int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, const CvLSVMFilterObjectCaskade *filter, float * cashM, int * maskM, int step);
-float calcFine (const CvLSVMFilterObjectCaskade *filter, int di, int dj);
+float calcM         (int k,int di,int dj, const CvLSVMFeaturePyramidCascade * H, const CvLSVMFilterObjectCascade *filter);
+float calcM_PCA     (int k,int di,int dj, const CvLSVMFeaturePyramidCascade * H, const CvLSVMFilterObjectCascade *filter);
+float calcM_PCA_cash(int k,int di,int dj, const CvLSVMFeaturePyramidCascade * H, const CvLSVMFilterObjectCascade *filter, float * cashM, int * maskM, int step);
+float calcFine (const CvLSVMFilterObjectCascade *filter, int di, int dj);
 }
 }
 #endif

--- a/modules/latentsvm/src/_lsvmc_latentsvm.h
+++ b/modules/latentsvm/src/_lsvmc_latentsvm.h
@@ -61,29 +61,29 @@ namespace lsvm
 // (pyramid constructed both contrast and non-contrast image)
 //////////////////////////////////////////////////////////////
 
-void FeaturePyramid32(CvLSVMFeaturePyramidCaskade* H, int maxX, int maxY);
+void FeaturePyramid32(CvLSVMFeaturePyramidCascade* H, int maxX, int maxY);
 
 /*
-// Creation PSA feature pyramid
+// Creation PCA feature pyramid
 //
 // API
-// featurePyramid* createPSA_FeaturePyramid(featurePyramid* H);
+// featurePyramid* createPCA_FeaturePyramid(featurePyramid* H);
 
 // INPUT
 // H                 - feature pyramid     
 // OUTPUT
 // RESULT
-// PSA feature pyramid
+// PCA feature pyramid
 */
-CvLSVMFeaturePyramidCaskade* createPCA_FeaturePyramid(CvLSVMFeaturePyramidCaskade* H, 
-                                               CvLatentSvmDetectorCaskade* detector, 
+CvLSVMFeaturePyramidCascade* createPCA_FeaturePyramid(CvLSVMFeaturePyramidCascade* H, 
+                                               CvLatentSvmDetectorCascade* detector, 
                                                int maxX, int maxY);
 
 /*
 // Getting feature pyramid  
 //
 // API
-// int getFeaturePyramid(IplImage * image, const CvLSVMFilterObjectCaskade **all_F, 
+// int getFeaturePyramid(IplImage * image, const CvLSVMFilterObjectCascade **all_F, 
                       const int n_f,
                       const int lambda, const int k, 
                       const int startX, const int startY, 
@@ -101,7 +101,7 @@ CvLSVMFeaturePyramidCaskade* createPCA_FeaturePyramid(CvLSVMFeaturePyramidCaskad
 // RESULT
 // Error status
 */
-int getFeaturePyramid(IplImage * image, CvLSVMFeaturePyramidCaskade **maps);
+int getFeaturePyramid(IplImage * image, CvLSVMFeaturePyramidCascade **maps);
 
 /*
 // Getting feature map for the selected subimage  
@@ -116,7 +116,7 @@ int getFeaturePyramid(IplImage * image, CvLSVMFeaturePyramidCaskade **maps);
 // RESULT
 // Error status
 */
-int getFeatureMaps(const IplImage * image, const int k, CvLSVMFeatureMapCaskade **map);
+int getFeatureMaps(const IplImage * image, const int k, CvLSVMFeatureMapCascade **map);
 
 
 /*
@@ -132,7 +132,7 @@ int getFeatureMaps(const IplImage * image, const int k, CvLSVMFeatureMapCaskade 
 // RESULT
 // Error status
 */
-int normalizeAndTruncate(CvLSVMFeatureMapCaskade *map, const float alfa);
+int normalizeAndTruncate(CvLSVMFeatureMapCascade *map, const float alfa);
 
 /*
 // Feature map reduction
@@ -148,7 +148,7 @@ int normalizeAndTruncate(CvLSVMFeatureMapCaskade *map, const float alfa);
 // RESULT
 // Error status
 */
-int PCAFeatureMaps(CvLSVMFeatureMapCaskade *map);
+int PCAFeatureMaps(CvLSVMFeatureMapCascade *map);
 
 //////////////////////////////////////////////////////////////
 // search object
@@ -227,7 +227,7 @@ int clippingBoxes(int width, int height,
 // RESULT
 // Feature pyramid with nullable border
 */
-CvLSVMFeaturePyramidCaskade* createFeaturePyramidWithBorder(IplImage *image,
+CvLSVMFeaturePyramidCascade* createFeaturePyramidWithBorder(IplImage *image,
                                                int maxXBorder, int maxYBorder);
 
 /*
@@ -235,7 +235,7 @@ CvLSVMFeaturePyramidCaskade* createFeaturePyramidWithBorder(IplImage *image,
 //
 // API
 // int searchObjectThresholdSomeComponents(const featurePyramid *H,
-                                           const CvLSVMFilterObjectCaskade **filters, 
+                                           const CvLSVMFilterObjectCascade **filters, 
                                            int kComponents, const int *kPartFilters,
                                            const float *b, float scoreThreshold,
                                            CvPoint **points, CvPoint **oppPoints,
@@ -255,9 +255,9 @@ CvLSVMFeaturePyramidCaskade* createFeaturePyramidWithBorder(IplImage *image,
 // RESULT
 // Error status
 */
-int searchObjectThresholdSomeComponents(const CvLSVMFeaturePyramidCaskade *H,
-										const CvLSVMFeaturePyramidCaskade *H_PCA,
-                                        const CvLSVMFilterObjectCaskade **filters, 
+int searchObjectThresholdSomeComponents(const CvLSVMFeaturePyramidCascade *H,
+										const CvLSVMFeaturePyramidCascade *H_PCA,
+                                        const CvLSVMFilterObjectCascade **filters, 
                                         int kComponents, const int *kPartFilters,
                                         const float *b, float scoreThreshold,
                                         CvPoint **points, CvPoint **oppPoints,
@@ -294,7 +294,7 @@ int getOppositePoint(CvPoint point,
 //
 // API
 // int showRootFilterBoxes(const IplImage *image,
-                           const CvLSVMFilterObjectCaskade *filter, 
+                           const CvLSVMFilterObjectCascade *filter, 
                            CvPoint *points, int *levels, int kPoints,
                            CvScalar color, int thickness, 
                            int line_type, int shift);
@@ -314,7 +314,7 @@ int getOppositePoint(CvPoint point,
 // Error status
 */
 int showRootFilterBoxes(IplImage *image,
-                        const CvLSVMFilterObjectCaskade *filter, 
+                        const CvLSVMFilterObjectCascade *filter, 
                         CvPoint *points, int *levels, int kPoints,
                         CvScalar color, int thickness, 
                         int line_type, int shift);
@@ -324,7 +324,7 @@ int showRootFilterBoxes(IplImage *image,
 //
 // API
 // int showPartFilterBoxes(const IplImage *image,
-                           const CvLSVMFilterObjectCaskade *filter, 
+                           const CvLSVMFilterObjectCascade *filter, 
                            CvPoint *points, int *levels, int kPoints,
                            CvScalar color, int thickness, 
                            int line_type, int shift);
@@ -345,7 +345,7 @@ int showRootFilterBoxes(IplImage *image,
 // Error status
 */
 int showPartFilterBoxes(IplImage *image,
-                        const CvLSVMFilterObjectCaskade **filters,
+                        const CvLSVMFilterObjectCascade **filters,
                         int n, CvPoint **partsDisplacement, 
                         int *levels, int kPoints,
                         CvScalar color, int thickness, 

--- a/modules/latentsvm/src/_lsvmc_matching.h
+++ b/modules/latentsvm/src/_lsvmc_matching.h
@@ -85,7 +85,7 @@ int computeBorderSize(int maxXBorder, int maxYBorder, int *bx, int *by);
 // RESULT
 // Error status
 */
-int addNullableBorder(CvLSVMFeatureMapCaskade *map, int bx, int by);
+int addNullableBorder(CvLSVMFeatureMapCascade *map, int bx, int by);
 
 /*
 // Perform non-maximum suppression algorithm (described in original paper)
@@ -117,12 +117,12 @@ int nonMaximumSuppression(int numBoxes, const CvPoint *points,
                           float overlapThreshold, 
                           int *numBoxesOut, CvPoint **pointsOut, 
                           CvPoint **oppositePointsOut, float **scoreOut);
-int getMaxFilterDims(const CvLSVMFilterObjectCaskade **filters, int kComponents,
+int getMaxFilterDims(const CvLSVMFilterObjectCascade **filters, int kComponents,
                      const int *kPartFilters, 
                      unsigned int *maxXBorder, unsigned int *maxYBorder);
 //}
 
-int getMaxFilterDims(const CvLSVMFilterObjectCaskade **filters, int kComponents,
+int getMaxFilterDims(const CvLSVMFilterObjectCascade **filters, int kComponents,
                      const int *kPartFilters, 
                      unsigned int *maxXBorder, unsigned int *maxYBorder);
 }

--- a/modules/latentsvm/src/_lsvmc_parser.h
+++ b/modules/latentsvm/src/_lsvmc_parser.h
@@ -116,7 +116,7 @@ namespace lsvm
               const char *modelPath,// model path
              
               // output parametrs
-              CvLSVMFilterObjectCaskade ***filters,
+              CvLSVMFilterObjectCascade ***filters,
               int *kFilters, 
               int *kComponents, 
               int **kPartFilters, 

--- a/modules/latentsvm/src/_lsvmc_routine.h
+++ b/modules/latentsvm/src/_lsvmc_routine.h
@@ -58,18 +58,18 @@ namespace lsvm
 // with all fields including arrays
 // Error status is return value
 //////////////////////////////////////////////////////////////
-int allocFilterObject(CvLSVMFilterObjectCaskade **obj, const int sizeX, const int sizeY, 
+int allocFilterObject(CvLSVMFilterObjectCascade **obj, const int sizeX, const int sizeY, 
                       const int p);
-int freeFilterObject (CvLSVMFilterObjectCaskade **obj);
+int freeFilterObject (CvLSVMFilterObjectCascade **obj);
 
-int allocFeatureMapObject(CvLSVMFeatureMapCaskade **obj, const int sizeX, const int sizeY,
+int allocFeatureMapObject(CvLSVMFeatureMapCascade **obj, const int sizeX, const int sizeY,
                           const int p);
-int freeFeatureMapObject (CvLSVMFeatureMapCaskade **obj);
+int freeFeatureMapObject (CvLSVMFeatureMapCascade **obj);
 
-int allocFeaturePyramidObject(CvLSVMFeaturePyramidCaskade **obj, 
+int allocFeaturePyramidObject(CvLSVMFeaturePyramidCascade **obj, 
                               const int countLevel);
 
-int freeFeaturePyramidObject (CvLSVMFeaturePyramidCaskade **obj);
+int freeFeaturePyramidObject (CvLSVMFeaturePyramidCascade **obj);
 
 }
 }

--- a/modules/latentsvm/src/_lsvmc_types.h
+++ b/modules/latentsvm/src/_lsvmc_types.h
@@ -96,7 +96,7 @@ typedef struct{
     int sizeY;
     int numFeatures;
     float *map;
-} CvLSVMFeatureMapCaskade;
+} CvLSVMFeatureMapCascade;
 
 // DataType: STRUCT featurePyramid
 //
@@ -104,8 +104,8 @@ typedef struct{
 // pyramid      - array of pointers to feature map at different levels
 typedef struct{
     int numLevels;
-    CvLSVMFeatureMapCaskade **pyramid;
-} CvLSVMFeaturePyramidCaskade;
+    CvLSVMFeatureMapCascade **pyramid;
+} CvLSVMFeaturePyramidCascade;
 
 // DataType: STRUCT filterDisposition
 // The structure stores preliminary results in optimization process
@@ -147,7 +147,7 @@ typedef struct CvLSVMFilterPosition
 //                   k - component of feature vector in cell (i, j)
 // END OF FILTER DESCRIPTION
 
-typedef struct CvLSVMFilterObjectCaskade{
+typedef struct CvLSVMFilterObjectCascade{
     CvLSVMFilterPosition V;
     float fineFunction[4];
     int sizeX;
@@ -159,7 +159,7 @@ typedef struct CvLSVMFilterObjectCaskade{
     float Hypothesis_PCA, Deformation_PCA;
     int deltaX;
     int deltaY;
-} CvLSVMFilterObjectCaskade;
+} CvLSVMFilterObjectCascade;
 
 // data type: STRUCT CvLatentSvmDetector
 // structure contains internal representation of trained Latent SVM detector
@@ -170,17 +170,17 @@ typedef struct CvLSVMFilterObjectCaskade{
 // b					- biases for all model components
 // score_threshold		- confidence level threshold
 
-typedef struct CvLatentSvmDetectorCaskade
+typedef struct CvLatentSvmDetectorCascade
 {
     int num_filters;
     int num_components;
     int* num_part_filters;
-    CvLSVMFilterObjectCaskade** filters;
+    CvLSVMFilterObjectCascade** filters;
     float* b;
     float score_threshold;
     float *pca;
     int pca_size;
-} CvLatentSvmDetectorCaskade;
+} CvLatentSvmDetectorCascade;
 }
 }
 #endif

--- a/modules/latentsvm/src/lsvmc_featurepyramid.cpp
+++ b/modules/latentsvm/src/lsvmc_featurepyramid.cpp
@@ -64,7 +64,7 @@ namespace lsvm
 
 int getPathOfFeaturePyramid(IplImage * image,
                             float step, int numStep, int startIndex,
-                            int sideLength, CvLSVMFeaturePyramidCaskade **maps);
+                            int sideLength, CvLSVMFeaturePyramidCascade **maps);
 
 /*
 // Getting feature map for the selected subimage
@@ -79,7 +79,7 @@ int getPathOfFeaturePyramid(IplImage * image,
 // RESULT
 // Error status
 */
-int getFeatureMaps(const IplImage* image, const int k, CvLSVMFeatureMapCaskade **map)
+int getFeatureMaps(const IplImage* image, const int k, CvLSVMFeatureMapCascade **map)
 {
     int sizeX, sizeY;
     int p, px, stringSize;
@@ -289,7 +289,7 @@ int getFeatureMaps(const IplImage* image, const int k, CvLSVMFeatureMapCaskade *
 // RESULT
 // Error status
 */
-int normalizeAndTruncate(CvLSVMFeatureMapCaskade *map, const float alfa)
+int normalizeAndTruncate(CvLSVMFeatureMapCascade *map, const float alfa)
 {
     int i,j, ii;
     int sizeX, sizeY, p, pos, pp, xp, pos1, pos2;
@@ -413,7 +413,7 @@ int normalizeAndTruncate(CvLSVMFeatureMapCaskade *map, const float alfa)
 // RESULT
 // Error status
 */
-int PCAFeatureMaps(CvLSVMFeatureMapCaskade *map)
+int PCAFeatureMaps(CvLSVMFeatureMapCascade *map)
 { 
     int i,j, ii, jj, k;
     int sizeX, sizeY, p,  pp, xp, yp, pos1, pos2;
@@ -485,9 +485,9 @@ int PCAFeatureMaps(CvLSVMFeatureMapCaskade *map)
 
 int getPathOfFeaturePyramid(IplImage * image, 
                             float step, int numStep, int startIndex,
-                            int sideLength, CvLSVMFeaturePyramidCaskade **maps)
+                            int sideLength, CvLSVMFeaturePyramidCascade **maps)
 {
-    CvLSVMFeatureMapCaskade *map;
+    CvLSVMFeatureMapCascade *map;
     IplImage *scaleTmp;
     float scale;
     int   i;
@@ -513,11 +513,11 @@ public:
     float step;
     int startIndex;
     int sideLength;
-    CvLSVMFeaturePyramidCaskade **maps;
+    CvLSVMFeaturePyramidCascade **maps;
 
     void operator() (const Range& range) const
     {
-        CvLSVMFeatureMapCaskade *map;
+        CvLSVMFeatureMapCascade *map;
         IplImage *scaleTmp;
         float scale;
         int   err;
@@ -538,7 +538,7 @@ public:
 
 int getPathOfFeaturePyramid_TBB(IplImage * image, 
                             float step, int numStep, int startIndex,
-                            int sideLength, CvLSVMFeaturePyramidCaskade **maps)
+                            int sideLength, CvLSVMFeaturePyramidCascade **maps)
 {
     PathOfFeaturePyramid str;
     str.step = step;
@@ -557,7 +557,7 @@ int getPathOfFeaturePyramid_TBB(IplImage * image,
 // Getting feature pyramid  
 //
 // API
-// int getFeaturePyramid(IplImage * image, const CvLSVMFilterObjectCaskade **all_F, 
+// int getFeaturePyramid(IplImage * image, const CvLSVMFilterObjectCascade **all_F, 
                       const int n_f,
                       const int lambda, const int k, 
                       const int startX, const int startY, 
@@ -569,7 +569,7 @@ int getPathOfFeaturePyramid_TBB(IplImage * image,
 // RESULT
 // Error status
 */
-int getFeaturePyramid(IplImage * image, CvLSVMFeaturePyramidCaskade **maps)
+int getFeaturePyramid(IplImage * image, CvLSVMFeaturePyramidCascade **maps)
 {
     IplImage *imgResize;
     float step;

--- a/modules/latentsvm/src/lsvmc_function.cpp
+++ b/modules/latentsvm/src/lsvmc_function.cpp
@@ -46,7 +46,7 @@ namespace cv
 namespace lsvm
 {
 
-float calcM    (int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, const CvLSVMFilterObjectCaskade *filter){
+float calcM    (int k,int di,int dj, const CvLSVMFeaturePyramidCascade * H, const CvLSVMFilterObjectCascade *filter){
     int i, j;
     float m = 0.0f;
     for(j = dj; j < dj + filter->sizeY; j++){
@@ -57,7 +57,7 @@ float calcM    (int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, cons
     }
     return m;
 }
-float calcM_PCA(int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, const CvLSVMFilterObjectCaskade *filter){
+float calcM_PCA(int k,int di,int dj, const CvLSVMFeaturePyramidCascade * H, const CvLSVMFilterObjectCascade *filter){
     int i, j;
     float m = 0.0f;
     for(j = dj; j < dj + filter->sizeY; j++){
@@ -69,7 +69,7 @@ float calcM_PCA(int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, cons
 
     return m;
 }
-float calcM_PCA_cash(int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H, const CvLSVMFilterObjectCaskade *filter, float * cashM, int * maskM, int step){
+float calcM_PCA_cash(int k,int di,int dj, const CvLSVMFeaturePyramidCascade * H, const CvLSVMFilterObjectCascade *filter, float * cashM, int * maskM, int step){
     int i, j, n;
     float m = 0.0f;
     float tmp1, tmp2, tmp3, tmp4;
@@ -119,7 +119,7 @@ float calcM_PCA_cash(int k,int di,int dj, const CvLSVMFeaturePyramidCaskade * H,
     }
     return m;
 }
-float calcFine (const CvLSVMFilterObjectCaskade *filter, int di, int dj){
+float calcFine (const CvLSVMFilterObjectCascade *filter, int di, int dj){
     return filter->fineFunction[0] * di      + filter->fineFunction[1] * dj + 
            filter->fineFunction[2] * di * di + filter->fineFunction[3] * dj * dj;
 }

--- a/modules/latentsvm/src/lsvmc_latentsvm.cpp
+++ b/modules/latentsvm/src/lsvmc_latentsvm.cpp
@@ -58,17 +58,17 @@ namespace lsvm
 int estimateBoxes(CvPoint *points, int *levels, int kPoints,
                   int sizeX, int sizeY, CvPoint **oppositePoints);
 
-int searchObjectThreshold(const CvLSVMFeaturePyramidCaskade *H,
-                          const CvLSVMFeaturePyramidCaskade *H_PCA,
-                          const CvLSVMFilterObjectCaskade **all_F, int n,
+int searchObjectThreshold(const CvLSVMFeaturePyramidCascade *H,
+                          const CvLSVMFeaturePyramidCascade *H_PCA,
+                          const CvLSVMFilterObjectCascade **all_F, int n,
                           float b,
                           int maxXBorder, int maxYBorder,
                           float scoreThreshold,
                           CvPoint **points, int **levels, int *kPoints,
                           float **score, CvPoint ***partsDisplacement);
 
-void FeaturePyramid32(CvLSVMFeaturePyramidCaskade* H, int maxX, int maxY){
-    CvLSVMFeatureMapCaskade *H32; 
+void FeaturePyramid32(CvLSVMFeaturePyramidCascade* H, int maxX, int maxY){
+    CvLSVMFeatureMapCascade *H32; 
     int i, j, k, l;
     int p  = H->pyramid[0]->numFeatures;
 
@@ -92,8 +92,8 @@ void FeaturePyramid32(CvLSVMFeaturePyramidCaskade* H, int maxX, int maxY){
     }
 }
 
-CvLSVMFeaturePyramidCaskade* createPCA_FeaturePyramid(CvLSVMFeaturePyramidCaskade* H, CvLatentSvmDetectorCaskade* detector, int maxX, int maxY){
-    CvLSVMFeaturePyramidCaskade *H_PCA; 
+CvLSVMFeaturePyramidCascade* createPCA_FeaturePyramid(CvLSVMFeaturePyramidCascade* H, CvLatentSvmDetectorCascade* detector, int maxX, int maxY){
+    CvLSVMFeaturePyramidCascade *H_PCA; 
     int i, j, k, l;
     int max_l = detector->pca_size;
     int p = H->pyramid[0]->numFeatures;
@@ -239,13 +239,13 @@ int clippingBoxes(int width, int height,
 // RESULT
 // Feature pyramid with nullable border
 */
-CvLSVMFeaturePyramidCaskade* createFeaturePyramidWithBorder(IplImage *image,
+CvLSVMFeaturePyramidCascade* createFeaturePyramidWithBorder(IplImage *image,
                                                int maxXBorder, int maxYBorder)
 {
     int opResult;
     int bx, by;
     int level;
-    CvLSVMFeaturePyramidCaskade *H;
+    CvLSVMFeaturePyramidCascade *H;
 
     // Obtaining feature pyramid
     opResult = getFeaturePyramid(image, &H);
@@ -303,7 +303,7 @@ int estimateBoxes(CvPoint *points, int *levels, int kPoints,
 //
 // API
 // int searchObjectThreshold(const featurePyramid *H, 
-                             const CvLSVMFilterObjectCaskade **all_F, int n,
+                             const CvLSVMFilterObjectCascade **all_F, int n,
                              float b, 
                              int maxXBorder, int maxYBorder, 
                              float scoreThreshold,
@@ -329,9 +329,9 @@ int estimateBoxes(CvPoint *points, int *levels, int kPoints,
 // RESULT
 // Error status
 */
-int searchObjectThreshold(const CvLSVMFeaturePyramidCaskade *H,
-                          const CvLSVMFeaturePyramidCaskade *H_PCA,
-                          const CvLSVMFilterObjectCaskade **all_F, int n,
+int searchObjectThreshold(const CvLSVMFeaturePyramidCascade *H,
+                          const CvLSVMFeaturePyramidCascade *H_PCA,
+                          const CvLSVMFilterObjectCascade **all_F, int n,
                           float b, 
                           int maxXBorder, int maxYBorder, 
                           float scoreThreshold,
@@ -630,7 +630,7 @@ int getOppositePoint(CvPoint point,
 //
 // API
 // int showRootFilterBoxes(const IplImage *image,
-                           const CvLSVMFilterObjectCaskade *filter, 
+                           const CvLSVMFilterObjectCascade *filter, 
                            CvPoint *points, int *levels, int kPoints,
                            CvScalar color, int thickness, 
                            int line_type, int shift);
@@ -650,7 +650,7 @@ int getOppositePoint(CvPoint point,
 // Error status
 */
 int showRootFilterBoxes(IplImage *image,
-                        const CvLSVMFilterObjectCaskade *filter, 
+                        const CvLSVMFilterObjectCascade *filter, 
                         CvPoint *points, int *levels, int kPoints,
                         CvScalar color, int thickness, 
                         int line_type, int shift)
@@ -679,7 +679,7 @@ int showRootFilterBoxes(IplImage *image,
 //
 // API
 // int showPartFilterBoxes(const IplImage *image,
-                           const CvLSVMFilterObjectCaskade *filter, 
+                           const CvLSVMFilterObjectCascade *filter, 
                            CvPoint *points, int *levels, int kPoints,
                            CvScalar color, int thickness, 
                            int line_type, int shift);
@@ -700,7 +700,7 @@ int showRootFilterBoxes(IplImage *image,
 // Error status
 */
 int showPartFilterBoxes(IplImage *image,
-                        const CvLSVMFilterObjectCaskade **filters,
+                        const CvLSVMFilterObjectCascade **filters,
                         int n, CvPoint **partsDisplacement, 
                         int *levels, int kPoints,
                         CvScalar color, int thickness, 
@@ -770,7 +770,7 @@ int showBoxes(IplImage *img,
 //// Computation maximum filter size for each dimension
 ////
 //// API
-//// int getMaxFilterDims(const CvLSVMFilterObjectCaskade **filters, int kComponents,
+//// int getMaxFilterDims(const CvLSVMFilterObjectCascade **filters, int kComponents,
 //                        const int *kPartFilters, 
 //                        unsigned int *maxXBorder, unsigned int *maxYBorder);
 //// INPUT
@@ -784,7 +784,7 @@ int showBoxes(IplImage *img,
 //// RESULT
 //// Error status
 //*/
-//int getMaxFilterDims(const CvLSVMFilterObjectCaskade **filters, int kComponents,
+//int getMaxFilterDims(const CvLSVMFilterObjectCascade **filters, int kComponents,
 //                     const int *kPartFilters, 
 //                     unsigned int *maxXBorder, unsigned int *maxYBorder)
 //{
@@ -812,9 +812,9 @@ int showBoxes(IplImage *img,
 
 class PathOfModel :public ParallelLoopBody{
     int *componentIndex;
-    const CvLSVMFeaturePyramidCaskade *H;
-    const CvLSVMFeaturePyramidCaskade *H_PCA;
-    const CvLSVMFilterObjectCaskade **filters;
+    const CvLSVMFeaturePyramidCascade *H;
+    const CvLSVMFeaturePyramidCascade *H_PCA;
+    const CvLSVMFilterObjectCascade **filters;
     const int *kPartFilters;
     const float *b;
     unsigned int maxXBorder, maxYBorder;
@@ -826,9 +826,9 @@ class PathOfModel :public ParallelLoopBody{
 public:
     PathOfModel(
       int *_componentIndex,
-    const CvLSVMFeaturePyramidCaskade *_H,
-    const CvLSVMFeaturePyramidCaskade *_H_PCA,
-    const CvLSVMFilterObjectCaskade **_filters,
+    const CvLSVMFeaturePyramidCascade *_H,
+    const CvLSVMFeaturePyramidCascade *_H_PCA,
+    const CvLSVMFilterObjectCascade **_filters,
     const int *_kPartFilters,
     const float *_b,
     unsigned int _maxXBorder, unsigned int _maxYBorder,
@@ -878,7 +878,7 @@ public:
 //
 // API
 // int searchObjectThresholdSomeComponents(const featurePyramid *H,
-                                           const CvLSVMFilterObjectCaskade **filters, 
+                                           const CvLSVMFilterObjectCascade **filters, 
                                            int kComponents, const int *kPartFilters,
                                            const float *b, float scoreThreshold,
                                            CvPoint **points, CvPoint **oppPoints,
@@ -898,9 +898,9 @@ public:
 // RESULT
 // Error status
 */
-int searchObjectThresholdSomeComponents(const CvLSVMFeaturePyramidCaskade *H,
-                                        const CvLSVMFeaturePyramidCaskade *H_PCA,
-                                        const CvLSVMFilterObjectCaskade **filters, 
+int searchObjectThresholdSomeComponents(const CvLSVMFeaturePyramidCascade *H,
+                                        const CvLSVMFeaturePyramidCascade *H_PCA,
+                                        const CvLSVMFilterObjectCascade **filters, 
                                         int kComponents, const int *kPartFilters,
                                         const float *b, float scoreThreshold,
                                         CvPoint **points, CvPoint **oppPoints,

--- a/modules/latentsvm/src/lsvmc_matching.cpp
+++ b/modules/latentsvm/src/lsvmc_matching.cpp
@@ -91,7 +91,7 @@ int computeBorderSize(int maxXBorder, int maxYBorder, int *bx, int *by)
 // RESULT
 // Error status
 */
-int addNullableBorder(CvLSVMFeatureMapCaskade *map, int bx, int by)
+int addNullableBorder(CvLSVMFeatureMapCascade *map, int bx, int by)
 {
     int sizeX, sizeY, i, j, k;
     float *new_map;
@@ -124,7 +124,7 @@ int addNullableBorder(CvLSVMFeatureMapCaskade *map, int bx, int by)
 // Computation maximum filter size for each dimension
 //
 // API
-// int getMaxFilterDims(const CvLSVMFilterObjectCaskade **filters, int kComponents,
+// int getMaxFilterDims(const CvLSVMFilterObjectCascade **filters, int kComponents,
                         const int *kPartFilters, 
                         unsigned int *maxXBorder, unsigned int *maxYBorder);
 // INPUT
@@ -138,7 +138,7 @@ int addNullableBorder(CvLSVMFeatureMapCaskade *map, int bx, int by)
 // RESULT
 // Error status
 */
-int getMaxFilterDims(const CvLSVMFilterObjectCaskade **filters, int kComponents,
+int getMaxFilterDims(const CvLSVMFilterObjectCascade **filters, int kComponents,
                      const int *kPartFilters, 
                      unsigned int *maxXBorder, unsigned int *maxYBorder)
 {

--- a/modules/latentsvm/src/lsvmc_parser.cpp
+++ b/modules/latentsvm/src/lsvmc_parser.cpp
@@ -79,26 +79,26 @@ int isHYPOTHES     (char *str);
 int isDEFORM       (char *str);
 int getTeg         (char *str);
 
-void addFilter(CvLSVMFilterObjectCaskade *** model, int *last, int *max);
+void addFilter(CvLSVMFilterObjectCascade *** model, int *last, int *max);
 
-void parserCascadeThresholds  (FILE * xmlf, CvLSVMFilterObjectCaskade * model);
+void parserCascadeThresholds  (FILE * xmlf, CvLSVMFilterObjectCascade * model);
 
-void parserRFilter  (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCaskade * model, float *b);
+void parserRFilter  (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCascade * model, float *b);
 
-void parserV  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCaskade * model);
+void parserV  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCascade * model);
 
-void parserD  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCaskade * model);
+void parserD  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCascade * model);
 
-void parserPFilter  (FILE * xmlf, int p, int pca, int /*N_path*/, CvLSVMFilterObjectCaskade * model);
+void parserPFilter  (FILE * xmlf, int p, int pca, int /*N_path*/, CvLSVMFilterObjectCascade * model);
 
-void parserPFilterS (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCaskade *** model, int *last, int *max);
+void parserPFilterS (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCascade *** model, int *last, int *max);
 
-void parserComp (FILE * xmlf, int p, int pca, int *N_comp, CvLSVMFilterObjectCaskade *** model, float *b, int *last, int *max);
+void parserComp (FILE * xmlf, int p, int pca, int *N_comp, CvLSVMFilterObjectCascade *** model, float *b, int *last, int *max);
 
-void parserModel(FILE * xmlf, CvLSVMFilterObjectCaskade *** model, int *last, int *max, int **comp, float **b, int *count, float * score, float** PCAcoeff);
+void parserModel(FILE * xmlf, CvLSVMFilterObjectCascade *** model, int *last, int *max, int **comp, float **b, int *count, float * score, float** PCAcoeff);
 
 void LSVMparser(const char * filename,
-                CvLSVMFilterObjectCaskade *** model,
+                CvLSVMFilterObjectCascade *** model,
                 int *last,
                 int *max,
                 int **comp,
@@ -336,21 +336,21 @@ int getTeg(char *str){
     return sum;
 }
 
-void addFilter(CvLSVMFilterObjectCaskade *** model, int *last, int *max)
+void addFilter(CvLSVMFilterObjectCascade *** model, int *last, int *max)
 {
-    CvLSVMFilterObjectCaskade ** nmodel;
+    CvLSVMFilterObjectCascade ** nmodel;
     int i;
     (*last) ++;
     if((*last) >= (*max)){
         (*max) += 10;
-        nmodel = (CvLSVMFilterObjectCaskade **)malloc(sizeof(CvLSVMFilterObjectCaskade *) * (*max));
+        nmodel = (CvLSVMFilterObjectCascade **)malloc(sizeof(CvLSVMFilterObjectCascade *) * (*max));
         for(i = 0; i < *last; i++){
             nmodel[i] = (* model)[i];
         }
         free(* model);
         (*model) = nmodel;
     }
-    (*model) [(*last)] = (CvLSVMFilterObjectCaskade *)malloc(sizeof(CvLSVMFilterObjectCaskade));
+    (*model) [(*last)] = (CvLSVMFilterObjectCascade *)malloc(sizeof(CvLSVMFilterObjectCascade));
     (*model) [(*last)]->Hypothesis      = 0.0f;
     (*model) [(*last)]->Deformation     = 0.0f;
     (*model) [(*last)]->Hypothesis_PCA  = 0.0f;
@@ -359,7 +359,7 @@ void addFilter(CvLSVMFilterObjectCaskade *** model, int *last, int *max)
 }
 
 //##############################################
-void parserCascadeThresholds  (FILE * xmlf, CvLSVMFilterObjectCaskade * model){
+void parserCascadeThresholds  (FILE * xmlf, CvLSVMFilterObjectCascade * model){
     int st = 0;
     int tag;
     int tagVal;
@@ -438,7 +438,7 @@ void parserCascadeThresholds  (FILE * xmlf, CvLSVMFilterObjectCaskade * model){
 }
 //##############################################
 
-void parserRFilter  (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCaskade * model, float *b){
+void parserRFilter  (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCascade * model, float *b){
     int st = 0;
     int sizeX = 0, sizeY = 0;
     int tag;
@@ -548,7 +548,7 @@ void parserRFilter  (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCaskade * mo
     }
 }
 
-void parserV  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCaskade * model){
+void parserV  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCascade * model){
     int st = 0;
     int tag;
     int tagVal;
@@ -611,7 +611,7 @@ void parserV  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCaskade * model){
         }        
     }
 }
-void parserD  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCaskade * model){
+void parserD  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCascade * model){
     int st = 0;
     int tag;
     int tagVal;
@@ -700,7 +700,7 @@ void parserD  (FILE * xmlf, int /*p*/, CvLSVMFilterObjectCaskade * model){
     }
 }
 
-void parserPFilter  (FILE * xmlf, int p, int pca, int /*N_path*/, CvLSVMFilterObjectCaskade * model){
+void parserPFilter  (FILE * xmlf, int p, int pca, int /*N_path*/, CvLSVMFilterObjectCascade * model){
     int st = 0;
     int sizeX = 0, sizeY = 0;
     int tag;
@@ -806,7 +806,7 @@ void parserPFilter  (FILE * xmlf, int p, int pca, int /*N_path*/, CvLSVMFilterOb
         }        
     }
 }
-void parserPFilterS (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCaskade *** model, int *last, int *max){
+void parserPFilterS (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCascade *** model, int *last, int *max){
     int st = 0;
     int N_path = 0;
     int tag;
@@ -850,7 +850,7 @@ void parserPFilterS (FILE * xmlf, int p, int pca, CvLSVMFilterObjectCaskade *** 
         }        
     }
 }
-void parserComp (FILE * xmlf, int p, int pca, int *N_comp, CvLSVMFilterObjectCaskade *** model, float *b, int *last, int *max){
+void parserComp (FILE * xmlf, int p, int pca, int *N_comp, CvLSVMFilterObjectCascade *** model, float *b, int *last, int *max){
     int st = 0;
     int tag;
     int tagVal;
@@ -895,7 +895,7 @@ void parserComp (FILE * xmlf, int p, int pca, int *N_comp, CvLSVMFilterObjectCas
         }        
     }
 }
-void parserModel(FILE * xmlf, CvLSVMFilterObjectCaskade *** model, int *last, int *max, int **comp, float **b, int *count, float * score, float** PCAcoeff){
+void parserModel(FILE * xmlf, CvLSVMFilterObjectCascade *** model, int *last, int *max, int **comp, float **b, int *count, float * score, float** PCAcoeff){
     int p = 0, pca = 0;
     int N_comp = 0;
     int * cmp;
@@ -1023,7 +1023,7 @@ void parserModel(FILE * xmlf, CvLSVMFilterObjectCaskade *** model, int *last, in
 }
 
 void LSVMparser(const char * filename, 
-                CvLSVMFilterObjectCaskade *** model, 
+                CvLSVMFilterObjectCascade *** model, 
                 int *last, 
                 int *max, 
                 int **comp, 
@@ -1040,7 +1040,7 @@ void LSVMparser(const char * filename,
 
     (*max) = 10;
     (*last) = -1;
-    (*model) = (CvLSVMFilterObjectCaskade ** )malloc((sizeof(CvLSVMFilterObjectCaskade * )) * (*max));
+    (*model) = (CvLSVMFilterObjectCascade ** )malloc((sizeof(CvLSVMFilterObjectCascade * )) * (*max));
 
     //printf("parse : %s\n", filename);
     xmlf = fopen(filename, "rb");
@@ -1075,7 +1075,7 @@ void LSVMparser(const char * filename,
 int loadModel(
               const char *modelPath,
              
-              CvLSVMFilterObjectCaskade ***filters,
+              CvLSVMFilterObjectCascade ***filters,
               int *kFilters, 
               int *kComponents, 
               int **kPartFilters, 

--- a/modules/latentsvm/src/lsvmc_routine.cpp
+++ b/modules/latentsvm/src/lsvmc_routine.cpp
@@ -45,11 +45,11 @@ namespace cv
 {
 namespace lsvm
 {
-int allocFilterObject(CvLSVMFilterObjectCaskade **obj, const int sizeX,
+int allocFilterObject(CvLSVMFilterObjectCascade **obj, const int sizeX,
                       const int sizeY, const int numFeatures) 
 {
     int i;
-    (*obj) = (CvLSVMFilterObjectCaskade *)malloc(sizeof(CvLSVMFilterObjectCaskade));
+    (*obj) = (CvLSVMFilterObjectCascade *)malloc(sizeof(CvLSVMFilterObjectCascade));
     (*obj)->sizeX           = sizeX;
     (*obj)->sizeY           = sizeY;
     (*obj)->numFeatures     = numFeatures;
@@ -68,7 +68,7 @@ int allocFilterObject(CvLSVMFilterObjectCaskade **obj, const int sizeX,
     }
     return LATENT_SVM_OK;
 }
-int freeFilterObject (CvLSVMFilterObjectCaskade **obj)
+int freeFilterObject (CvLSVMFilterObjectCascade **obj)
 {
     if(*obj == NULL) return LATENT_SVM_MEM_NULL;
     free((*obj)->H);
@@ -77,11 +77,11 @@ int freeFilterObject (CvLSVMFilterObjectCaskade **obj)
     return LATENT_SVM_OK;
 }
 
-int allocFeatureMapObject(CvLSVMFeatureMapCaskade **obj, const int sizeX, 
+int allocFeatureMapObject(CvLSVMFeatureMapCascade **obj, const int sizeX, 
                           const int sizeY, const int numFeatures)
 {
     int i;
-    (*obj) = (CvLSVMFeatureMapCaskade *)malloc(sizeof(CvLSVMFeatureMapCaskade));
+    (*obj) = (CvLSVMFeatureMapCascade *)malloc(sizeof(CvLSVMFeatureMapCascade));
     (*obj)->sizeX       = sizeX;
     (*obj)->sizeY       = sizeY;
     (*obj)->numFeatures = numFeatures;
@@ -93,7 +93,7 @@ int allocFeatureMapObject(CvLSVMFeatureMapCaskade **obj, const int sizeX,
     }
     return LATENT_SVM_OK;
 }
-int freeFeatureMapObject (CvLSVMFeatureMapCaskade **obj)
+int freeFeatureMapObject (CvLSVMFeatureMapCascade **obj)
 {
     if(*obj == NULL) return LATENT_SVM_MEM_NULL;
     free((*obj)->map);
@@ -102,17 +102,17 @@ int freeFeatureMapObject (CvLSVMFeatureMapCaskade **obj)
     return LATENT_SVM_OK;
 }
 
-int allocFeaturePyramidObject(CvLSVMFeaturePyramidCaskade **obj,
+int allocFeaturePyramidObject(CvLSVMFeaturePyramidCascade **obj,
                               const int numLevels) 
 {
-    (*obj) = (CvLSVMFeaturePyramidCaskade *)malloc(sizeof(CvLSVMFeaturePyramidCaskade));
+    (*obj) = (CvLSVMFeaturePyramidCascade *)malloc(sizeof(CvLSVMFeaturePyramidCascade));
     (*obj)->numLevels = numLevels;
-    (*obj)->pyramid    = (CvLSVMFeatureMapCaskade **)malloc(
-                         sizeof(CvLSVMFeatureMapCaskade *) * numLevels);
+    (*obj)->pyramid    = (CvLSVMFeatureMapCascade **)malloc(
+                         sizeof(CvLSVMFeatureMapCascade *) * numLevels);
     return LATENT_SVM_OK;
 }
 
-int freeFeaturePyramidObject (CvLSVMFeaturePyramidCaskade **obj)
+int freeFeaturePyramidObject (CvLSVMFeaturePyramidCascade **obj)
 {
     int i; 
     if(*obj == NULL) return LATENT_SVM_MEM_NULL;

--- a/modules/latentsvm/test/test_latentsvmdetector_cascade.cpp
+++ b/modules/latentsvm/test/test_latentsvmdetector_cascade.cpp
@@ -56,7 +56,7 @@ using namespace cv;
 
 const float score_thr = 0.05f;
 
-class LatentSVMDetectorCaskadeTest : public cvtest::BaseTest
+class LatentSVMDetectorCascadeTest : public cvtest::BaseTest
 {
 protected:
     void run(int);
@@ -125,15 +125,16 @@ bool compareResults( const std::vector<lsvm::LSVMDetector::ObjectDetection>& cal
     return true;
 }
 
-void LatentSVMDetectorCaskadeTest::run( int /* start_from */)
+void LatentSVMDetectorCascadeTest::run( int /* start_from */)
 {
-    std::string img_path_cat = std::string(ts->get_data_path()) + "cat.png";
-    std::string img_path_cars = std::string(ts->get_data_path()) + "cars.png";
+    std::string test_data_path = ts->get_data_path() + "latentsvmdetector/";
+    std::string img_path_cat = test_data_path  + "cat.png";
+    std::string img_path_cars = test_data_path + "cars.png";
 
-    std::string model_path_cat = std::string(ts->get_data_path()) + "models_VOC2007_cascade/cat.xml";
-    std::string model_path_car = std::string(ts->get_data_path()) + "models_VOC2007_cascade/car.xml";
+    std::string model_path_cat = test_data_path + "models_VOC2007_cascade/cat.xml";
+    std::string model_path_car = test_data_path + "models_VOC2007_cascade/car.xml";
 
-    std::string true_res_path = std::string(ts->get_data_path()) + "results_cascade.xml";
+    std::string true_res_path = test_data_path + "results_cascade.xml";
 
 
 #ifdef HAVE_TBB
@@ -214,4 +215,4 @@ void LatentSVMDetectorCaskadeTest::run( int /* start_from */)
     ts->set_failed_test_info( cvtest::TS::OK);
 }
 
-TEST(Objdetect_LatentSVMDetectorCaskade_cpp, regression) { LatentSVMDetectorCaskadeTest test; test.safe_run(); }
+TEST(Objdetect_LatentSVMDetectorCascade_cpp, regression) { LatentSVMDetectorCascadeTest test; test.safe_run(); }

--- a/modules/latentsvm/test/test_main.cpp
+++ b/modules/latentsvm/test/test_main.cpp
@@ -1,3 +1,3 @@
 #include "test_precomp.hpp"
 
-CV_TEST_MAIN("latentsvm")
+CV_TEST_MAIN("cv")


### PR DESCRIPTION
This pull request is related to the issue
https://github.com/Itseez/opencv_contrib/issues/191

and another pull request on opencv_extra
https://github.com/Itseez/opencv_extra/pull/248

Now, the testing should work:
```sh
$ ./opencv_test_latentsvm 
OpenCV version: 3.0.0-dev
OpenCV VCS version: 3.0.0-beta-732-gd2da7dc
Build type: debug
CPU features: mmx sse sse2 sse3
OpenCL is disabled
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from Objdetect_LatentSVMDetectorCaskade_cpp
[ RUN      ] Objdetect_LatentSVMDetectorCaskade_cpp.regression
[       OK ] Objdetect_LatentSVMDetectorCaskade_cpp.regression (25694 ms)
[----------] 1 test from Objdetect_LatentSVMDetectorCaskade_cpp (25694 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (25694 ms total)
[  PASSED  ] 1 test.
```
