### PR TITLE
Fix (typo) bug in AGAST scoring routines.

### DIFF
--- a/modules/xfeatures2d/src/agast_score.cpp
+++ b/modules/xfeatures2d/src/agast_score.cpp
@@ -118,8 +118,8 @@ int agast_cornerScore<AgastFeatureDetector::OAST_9_16>(const uchar* ptr, const i
 
     while(true)
     {
-        register const int cb = *pixel + b_test;
-        register const int c_b = *pixel - b_test;
+        register const int cb = *ptr + b_test;
+        register const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset2] > cb)
             if(ptr[offset4] > cb)
@@ -2189,8 +2189,8 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_7_12d>(const uchar* ptr, const
 
     while(true)
     {
-        register const int cb = *pixel + b_test;
-        register const int c_b = *pixel - b_test;
+        register const int cb = *ptr + b_test;
+        register const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset5] > cb)
             if(ptr[offset2] > cb)
@@ -3401,8 +3401,8 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_7_12s>(const uchar* ptr, const
 
     while(true)
     {
-        register const int cb = *pixel + b_test;
-        register const int c_b = *pixel - b_test;
+        register const int cb = *ptr + b_test;
+        register const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset5] > cb)
             if(ptr[offset2] < c_b)
@@ -9031,8 +9031,8 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_5_8>(const uchar* ptr, const i
 
     while(true)
     {
-        register const int cb = *pixel + b_test;
-        register const int c_b = *pixel - b_test;
+        register const int cb = *ptr + b_test;
+        register const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset2] > cb)
             if(ptr[offset3] > cb)


### PR DESCRIPTION
 - This small patch fix an obvious bug in AGAST scoring routine. The bug is due to accidental typo during transcript. AGAST is now verified and produce 1:1 same scoring as the original code.
