### PR TITLE
Bugfix Normalization / Enhance "float/double" mode queries for DAISY.

### DIFF
--- a/modules/xfeatures2d/src/daisy.cpp
+++ b/modules/xfeatures2d/src/daisy.cpp
@@ -519,8 +519,7 @@ static void normalize_sift_way( float* desc, const int _descriptor_size )
       double sum = 0.0f;
       for( int i=0; i<_descriptor_size; i++ )
       {
-          sum += desc[_descriptor_size + i]
-               * desc[_descriptor_size + i];
+          sum += desc[i] * desc[i];
       }
 
       float norm = (float)sqrt( sum );
@@ -529,7 +528,7 @@ static void normalize_sift_way( float* desc, const int _descriptor_size )
       // divide with norm
       for( int i=0; i<_descriptor_size; i++ )
       {
-          desc[_descriptor_size + i] /= norm;
+          desc[i] /= norm;
       }
 
       for( h=0; h<_descriptor_size; h++ )
@@ -549,8 +548,7 @@ static void normalize_full( float* desc, const int _descriptor_size )
     double sum = 0.0f;
     for( int i=0; i<_descriptor_size; i++ )
     {
-        sum += desc[_descriptor_size + i]
-             * desc[_descriptor_size + i];
+        sum += desc[i] * desc[i];
     }
 
     float norm = (float)sqrt( sum );
@@ -559,7 +557,7 @@ static void normalize_full( float* desc, const int _descriptor_size )
     // divide with norm
     for( int i=0; i<_descriptor_size; i++ )
     {
-        desc[_descriptor_size + i] /= norm;
+        desc[i] /= norm;
     }
 }
 
@@ -1547,8 +1545,6 @@ void DAISY_Impl::compute( InputArray _image, Rect roi, OutputArray _descriptors 
     // compute full desc
     compute_descriptors( &descriptors );
     normalize_descriptors( &descriptors );
-
-    release_auxiliary();
 }
 
 // full scope
@@ -1576,8 +1572,6 @@ void DAISY_Impl::compute( InputArray _image, OutputArray _descriptors )
     // compute full desc
     compute_descriptors( &descriptors );
     normalize_descriptors( &descriptors );
-
-    release_auxiliary();
 }
 
 // constructor


### PR DESCRIPTION

After more QA tests, went to check if DAISY objects can be further queried with GetDescriptor( double x, double y) optional queries for going from coarse (precomputed descriptors at integer x,y locations) to fine grained double precision (x,y) query mode to find the perfect minima at subpixel level, thus gaining more precise depth at projected 3d location, and some outstanding and important fixes still need to be done for DAISY for this mode:
    
 1. Normalization routines still suffers an outstanding bug ! Apologies that i did not saw it at #243 .
 2. Do not aux_release() DAISY's objects in dense mode, thus locations (x,y) can be further queried !
 3. For no .2 DAISY object will be destroyed by its destructor or by calling .release() over the object.
 4. Remark: Our GetDescriptor() const works perfect in multithreded scenarios just as expected.

With this additional fix DAISY still produce better results than original one. Re-done the basic dense scanning over castle-p11 image set:

original: 4026934 (3d points)
opencv: 4179047 (3d points) after #243 (still in degraded mode)
**opencv:**4854773 (3d points) after this PR.

I am apologising to not see within #243 this obvious nasty bug.