### PR TITLE
Bug fix for seeds superpixel

### DIFF
--- a/modules/ximgproc/src/seeds.cpp
+++ b/modules/ximgproc/src/seeds.cpp
@@ -273,8 +273,8 @@ void SuperpixelSEEDSImpl::initialize(int num_superpixels, int num_levels)
     parent_pre_init.resize(seeds_nr_levels);
     nr_wh.resize(2 * seeds_nr_levels);
     int level = 0;
-    int nr_seeds_w = (int)floor(width / seeds_w);
-    int nr_seeds_h = (int)floor(height / seeds_h);
+    int nr_seeds_w = (int)float(floor((float)width / seeds_w));
+    int nr_seeds_h = (int)float(floor((float)height / seeds_h));
     nr_wh[2 * level] = nr_seeds_w;
     nr_wh[2 * level + 1] = nr_seeds_h;
     parent_mat.push_back(Mat(nr_seeds_h, nr_seeds_w, CV_32SC1));


### PR DESCRIPTION
When useing VS2010 compile seeds.cpp, here will prompt an error because
the overloading problem.Take float to tell the Compiler.