### PR TITLE
Fixed bug in LSDDetector where mask doesn't remove all undesired lines

### DIFF
--- a/modules/line_descriptor/src/LSDDetector.cpp
+++ b/modules/line_descriptor/src/LSDDetector.cpp
@@ -203,7 +203,10 @@ void LSDDetector::detectImpl( const Mat& imageSrc, std::vector<KeyLine>& keyline
     {
       KeyLine kl = keylines[keyCounter];
       if( mask.at<uchar>( (int) kl.startPointY, (int) kl.startPointX ) == 0 && mask.at<uchar>( (int) kl.endPointY, (int) kl.endPointX ) == 0 )
+      {
         keylines.erase( keylines.begin() + keyCounter );
+        keyCounter--;
+      }
     }
   }
 


### PR DESCRIPTION
I noticed the mask feature in LSDDetector::detect wasn't working so I looked at the code and realized that the keyCounter isn't decremented when an line is erased. This causes the loop to skip over a line which ends up screwing the mask feature. Adding the decrement fixed the problem.