### PR TITLE
make sources compile again on MSVC 2012 (VC 11) by adding round()

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -42,7 +42,7 @@
 #include "precomp.hpp"
 
 #ifdef _MSC_VER
-    #if (__cplusplus <= 199711L)
+    #if (_MSC_VER <= 1700)
         /* This function rounds x to the nearest integer, but rounds halfway cases away from zero. */
         static inline double round(double x)
         {

--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -41,6 +41,19 @@
 
 #include "precomp.hpp"
 
+#ifdef _MSC_VER
+    #if (__cplusplus <= 199711L)
+        /* This function rounds x to the nearest integer, but rounds halfway cases away from zero. */
+        static inline double round(double x)
+        {
+            if (x < 0.0)
+                return ceil(x - 0.5);
+            else
+                return floor(x + 0.5);
+        }
+    #endif
+#endif
+
 #define NUM_OF_BANDS 9
 #define Horizontal  255//if |dx|<|dy|;
 #define Vertical    0//if |dy|<=|dx|;

--- a/modules/line_descriptor/src/bitops.hpp
+++ b/modules/line_descriptor/src/bitops.hpp
@@ -101,7 +101,7 @@ inline void split( UINT64 *chunks, UINT8 *code, int m, int mplus, int b )
   UINT64 temp = 0x0;
   int nbits = 0;
   int nbyte = 0;
-  UINT64 mask = b == 64 ? 0xFFFFFFFFFFFFFFFFLLU : ( ( UINT64_1 << b ) - UINT64_1 );
+  UINT64 mask = (b == 64) ? 0xFFFFFFFFFFFFFFFFull : ( ( UINT64_1 << b ) - UINT64_1 );
 
   for ( int i = 0; i < m; i++ )
   {

--- a/modules/saliency/src/motionSaliencyBinWangApr2014.cpp
+++ b/modules/saliency/src/motionSaliencyBinWangApr2014.cpp
@@ -479,7 +479,7 @@ bool MotionSaliencyBinWangApr2014::templateReplacement( const Mat& finalBFMask, 
                 /////////////////// REPLACEMENT of backgroundModel template ///////////////////
                 //replace TA with current TK
                 backgroundModel[backgroundModel.size() - 1]->at<Vec2f>( i, j ) = potentialBackground.at<Vec2f>( i, j );
-                potentialBackground.at<Vec2f>( i, j )[0] = NAN;
+                potentialBackground.at<Vec2f>( i, j )[0] = (float)NAN;
                 potentialBackground.at<Vec2f>( i, j )[1] = 0;
 
                 break;
@@ -489,7 +489,7 @@ bool MotionSaliencyBinWangApr2014::templateReplacement( const Mat& finalBFMask, 
           else
           {
             backgroundModel[backgroundModel.size() - 1]->at<Vec2f>( i, j ) = potentialBackground.at<Vec2f>( i, j );
-            potentialBackground.at<Vec2f>( i, j )[0] = NAN;
+            potentialBackground.at<Vec2f>( i, j )[0] = (float)NAN;
             potentialBackground.at<Vec2f>( i, j )[1] = 0;
           }
         }  // close if of EVALUATION

--- a/modules/tracking/src/tldDataset.cpp
+++ b/modules/tracking/src/tldDataset.cpp
@@ -52,7 +52,10 @@ namespace cv
 		cv::Rect2d tld_InitDataset(int datasetInd,const char* rootPath)
 		{
 			char* folderName = (char *)"";
-			int x, y, w, h;
+			int x = 0;
+			int y = 0;
+			int w = 0;
+			int h = 0;
 			flagPNG = false;
 
 			frameNum = 1;


### PR DESCRIPTION
MSVC had no implemenation for round() in earlier versions.
support for round() was probably first added with MSVC 2013.