### PR TITLE
Fix several bugs in aruco module

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -114,7 +114,7 @@ namespace aruco {
  *   size of the cell, i.e. perpectiveRemovePixelPerCell (default 0.13)
  * - maxErroneousBitsInBorderRate: maximum number of accepted erroneous bits in the border (i.e.
  *   number of allowed white bits in the border). Represented as a rate respect to the total
- *   number of bits per marker (default 0.5).
+ *   number of bits per marker (default 0.35).
  * - minOtsuStdDev: minimun standard deviation in pixels values during the decodification step to
  *   apply Otsu thresholding (otherwise, all the bits are set to 0 or 1 depending on mean higher
  *   than 128 or not) (default 5.0)

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -71,7 +71,7 @@ DetectorParameters::DetectorParameters()
       markerBorderBits(1),
       perspectiveRemovePixelPerCell(4),
       perspectiveRemoveIgnoredMarginPerCell(0.13),
-      maxErroneousBitsInBorderRate(0.5),
+      maxErroneousBitsInBorderRate(0.35),
       minOtsuStdDev(5.0),
       errorCorrectionRate(0.6) {}
 
@@ -123,7 +123,7 @@ static void _findMarkerContours(InputArray _in, vector< vector< Point2f > > &can
     Mat contoursImg;
     _in.getMat().copyTo(contoursImg);
     vector< vector< Point > > contours;
-    findContours(contoursImg, contours, RETR_EXTERNAL, CHAIN_APPROX_NONE);
+    findContours(contoursImg, contours, RETR_LIST, CHAIN_APPROX_NONE);
     // now filter list of contours
     for(unsigned int i = 0; i < contours.size(); i++) {
         // check perimeter

--- a/modules/aruco/src/dictionary.cpp
+++ b/modules/aruco/src/dictionary.cpp
@@ -275,7 +275,7 @@ Mat Dictionary::getBitsFromByteList(const Mat &byteList, int markerSize) {
 
 
 // DictionaryData constructors calls
-const Dictionary DICT_ARUCO_DATA = Dictionary(&(DICT_ARUCO_BYTES[0][0][0]), 5, 1024, 1);
+const Dictionary DICT_ARUCO_DATA = Dictionary(&(DICT_ARUCO_BYTES[0][0][0]), 5, 1024, 0);
 
 const Dictionary DICT_4X4_50_DATA = Dictionary(&(DICT_4X4_1000_BYTES[0][0][0]), 4, 50, 1);
 const Dictionary DICT_4X4_100_DATA = Dictionary(&(DICT_4X4_1000_BYTES[0][0][0]), 4, 100, 1);

--- a/modules/aruco/tutorials/aruco_detection/aruco_detection.markdown
+++ b/modules/aruco/tutorials/aruco_detection/aruco_detection.markdown
@@ -665,7 +665,7 @@ The bits of the marker border should be black. This parameter specifies the allo
 bits in the border, i.e. the maximum number of white bits in the border. It is represented
 relative to the total number of bits in the marker.
 
-Default value: 0.5
+Default value: 0.35
 
 
 - ```double errorCorrectionRate```


### PR DESCRIPTION
This PR fixes several bugs in the aruco module:

- Set ```RETR_LIST``` in the ```findContours()``` function. This was an important bug that was producing many false negatives.
- Fix ```DICT_ARUCO_ORIGINAL``` error correction capacity.
- Set a better value for the parameter ```maxErroneousBitsInBorderRate```

I am preparing another PR with all the last comments/changes proposed by Prasanna.  However, I thought it was important to fix these bugs as soon as possible. 