### PR TITLE
Draw keylines in random color by default as documentation depicts

### DIFF
--- a/modules/line_descriptor/src/draw.cpp
+++ b/modules/line_descriptor/src/draw.cpp
@@ -166,7 +166,7 @@ void drawKeylines( const Mat& image, const std::vector<KeyLine>& keylines, Mat& 
   {
     /* decide lines' color  */
     Scalar lineColor;
-    if( color != Scalar::all( -1 ) )
+    if( color == Scalar::all( -1 ) )
     {
       int R = ( rand() % (int) ( 255 + 1 ) );
       int G = ( rand() % (int) ( 255 + 1 ) );


### PR DESCRIPTION
Fix bug that color is not chosen randomly when no color argument is supplied (default) as the documentation depicts and also is the case in drawLineMatches.