### PR TITLE
opencv_dnn: replaced static LayerFactory::impl member with a static function that constructs the object on the first use (fix for bug #383)

### DIFF
--- a/modules/dnn/include/opencv2/dnn/layer.hpp
+++ b/modules/dnn/include/opencv2/dnn/layer.hpp
@@ -77,7 +77,7 @@ private:
     LayerFactory();
 
     struct Impl;
-    static Ptr<Impl> impl;
+    static Ptr<Impl> impl();
 };
 
 /** @brief Registers layer constructor in runtime.

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -561,34 +561,38 @@ struct LayerFactory::Impl : public std::map<String, LayerFactory::Constuctor>
 {
 };
 
-//allocates on load and cleans on exit
-Ptr<LayerFactory::Impl> LayerFactory::impl(new LayerFactory::Impl());
+Ptr<LayerFactory::Impl> LayerFactory::impl ()
+{
+    // allocate on first use
+    static Ptr<LayerFactory::Impl> impl_(new LayerFactory::Impl());
+    return impl_;
+}
 
 void LayerFactory::registerLayer(const String &_type, Constuctor constructor)
 {
     String type = _type.toLowerCase();
-    Impl::iterator it = impl->find(type);
+    Impl::iterator it = impl()->find(type);
 
-    if (it != impl->end() && it->second != constructor)
+    if (it != impl()->end() && it->second != constructor)
     {
         CV_Error(cv::Error::StsBadArg, "Layer \"" + type + "\" already was registered");
     }
 
-    impl->insert(std::make_pair(type, constructor));
+    impl()->insert(std::make_pair(type, constructor));
 }
 
 void LayerFactory::unregisterLayer(const String &_type)
 {
     String type = _type.toLowerCase();
-    impl->erase(type);
+    impl()->erase(type);
 }
 
 Ptr<Layer> LayerFactory::createLayerInstance(const String &_type, LayerParams& params)
 {
     String type = _type.toLowerCase();
-    Impl::const_iterator it = LayerFactory::impl->find(type);
+    Impl::const_iterator it = LayerFactory::impl()->find(type);
 
-    if (it != impl->end())
+    if (it != impl()->end())
     {
         return it->second(params);
     }


### PR DESCRIPTION
This way, we are certain not to depend on the order of static
variable initialization (LayerFactory::impl in dnn.cpp, vs. init
in init.cpp), which is causing bug #383.