### PR TITLE
remove datasetstools

### DIFF
--- a/modules/datasetstools/README.md
+++ b/modules/datasetstools/README.md
@@ -1,2 +1,0 @@
-Tools for working with different datasets
-=========================================


### PR DESCRIPTION
the former datasetstools module got renamed to datasets, this is an obsolete remainder, which got [added again](https://github.com/Itseez/opencv_contrib/commit/38bdd6f3f41bd62295efd768f4626cadbf350a6b), with the readme's