### PR TITLE
Fix comple error with opencv 3.0 on Nvidia Jetson

### DIFF
--- a/modules/cvv/src/view/linematchview.cpp
+++ b/modules/cvv/src/view/linematchview.cpp
@@ -45,7 +45,8 @@ LineMatchView::LineMatchView(std::vector<cv::KeyPoint> leftKeyPoints,
 	qtutil::MatchScene *matchscene_ptr = matchscene.get();
 	int updateAreaDelay=std::min(std::max(matches.size(),
 					      std::max(leftKeyPoints.size(),
-						       rightKeyPoints.size()))/10,50lu);
+						       rightKeyPoints.size()))/std::size_t{10},
++	                              std::size_t{50});
 	matchscene_ptr->getLeftImage().setUpdateAreaDelay(updateAreaDelay);
 	matchscene_ptr->getRightImage().setUpdateAreaDelay(updateAreaDelay);
 

--- a/modules/cvv/src/view/pointmatchview.cpp
+++ b/modules/cvv/src/view/pointmatchview.cpp
@@ -30,7 +30,8 @@ PointMatchView::PointMatchView(std::vector<cv::KeyPoint> leftKeyPoints,
 	auto matchmnt = util::make_unique<qtutil::MatchManagement>(matches);
 
 	qtutil::MatchScene *matchscene_ptr = matchscene.get();
-	int updateAreaDelay=std::min(std::max(matches.size(),std::max(leftKeyPoints.size(),rightKeyPoints.size()))/10,50lu);
+	int updateAreaDelay=std::min(std::max(matches.size(),std::max(leftKeyPoints.size(),rightKeyPoints.size()))/std::size_t{10},
++	                              std::size_t{50});
 	matchscene_ptr->getLeftImage().setUpdateAreaDelay(updateAreaDelay);
 	matchscene_ptr->getRightImage().setUpdateAreaDelay(updateAreaDelay);
 

--- a/modules/cvv/src/view/translationsmatchview.cpp
+++ b/modules/cvv/src/view/translationsmatchview.cpp
@@ -39,7 +39,8 @@ TranslationMatchView::TranslationMatchView(
 	auto keyPointmnt = util::make_unique<qtutil::KeyPointManagement>(allkeypoints);
 
 	qtutil::MatchScene *matchscene_ptr = matchscene.get();
-	int updateAreaDelay=std::min(std::max(matches.size(),std::max(leftKeyPoints.size(),rightKeyPoints.size()))/10,50lu);
+	int updateAreaDelay=std::min(std::max(matches.size(),std::max(leftKeyPoints.size(),rightKeyPoints.size()))/std::size_t{10},
++	                              std::size_t{50});
 	matchscene_ptr->getLeftImage().setUpdateAreaDelay(updateAreaDelay);
 	matchscene_ptr->getRightImage().setUpdateAreaDelay(updateAreaDelay);
 


### PR DESCRIPTION
This re-creates a fix for a bug reported here: https://github.com/CVVisualPSETeam/CVVisual/issues/46. 

The original fix is show here: https://github.com/CVVisualPSETeam/CVVisual/commit/f7b1c68cb693167c6fd8656e91fab3d1da07d1bb

This fix applies the replacement of 10,50lu with std::size_t{10},  std::size_t{50} in the three files.
