### PR TITLE
datasets: make most dependancies optional

### DIFF
--- a/modules/datasets/CMakeLists.txt
+++ b/modules/datasets/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(the_description "datasets framework")
-ocv_define_module(datasets opencv_core opencv_face opencv_ml opencv_flann opencv_text WRAP python)
+ocv_define_module(datasets opencv_core OPTIONAL opencv_face opencv_ml opencv_flann opencv_text)
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4267) # flann, Win64


### PR DESCRIPTION
the datasets module itself only depends on core, all other dependancies are for the samples only , and should be optional

also, since nothing is exposed to script wrappers, remove python bindings

see [428](https://github.com/Itseez/opencv_contrib/issues/428)