### PR TITLE
Fixes clang compilation error

### DIFF
--- a/modules/cvv/src/stfl/stfl_engine.hpp
+++ b/modules/cvv/src/stfl/stfl_engine.hpp
@@ -1053,7 +1053,7 @@ private:
 		{
 			return QStringList();
 		}
-		return settings.value(key).value<QStringList>();
+		return settings.value(key).template value<QStringList>();
 	}
 
 	QStringList getStoredCmdsForInput(QString input)


### PR DESCRIPTION
According to ISO C++03 14.2/4 it should use the template keyword to fix this => http://stackoverflow.com/a/3786481/724098.

Fixes https://github.com/Itseez/opencv_contrib/issues/272 and https://github.com/Itseez/opencv_contrib/issues/381