### PR TITLE
Fixed the issue #5032 posted in opencv

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -92,6 +92,7 @@ ocv_add_module(matlab   BINDINGS
                                  opencv_calib opencv_calib3d
                                  opencv_stitching opencv_superres
                                  opencv_xfeatures2d
+                                 opencv_hal
 )
 
 # get the commit information


### PR DESCRIPTION
This commit aims to fix issue [#5032](https://github.com/Itseez/opencv/issues/5032) posted in opencv.

The missing line causes the following error message when compiling using VS2012:

    fatal error C1083: Cannot open include file: 'opencv2/hal/defs.h': No such file or directory
which fails the compilation of matlab binding.