### PR TITLE
Fixed issue caused by missing round() in VS before 2013

### DIFF
--- a/modules/dpm/src/dpm_feature.cpp
+++ b/modules/dpm/src/dpm_feature.cpp
@@ -47,6 +47,7 @@ namespace cv
 {
 namespace dpm
 {
+
 Feature::Feature()
 {
 }
@@ -196,8 +197,8 @@ void Feature::computeHOG32D(const Mat &imageM, Mat &featM, const int sbin, const
     // image size
     const Size imageSize = imageM.size();
     // block size
-    int bW = (int)round((double)imageSize.width/(double)sbin);
-    int bH = (int)round((double)imageSize.height/(double)sbin);
+    int bW = cvRound((double)imageSize.width/(double)sbin);
+    int bH = cvRound((double)imageSize.height/(double)sbin);
     const Size blockSize(bW, bH);
     // size of HOG features
     int oW = max(blockSize.width-2, 0) + 2*pad_x;


### PR DESCRIPTION
This commit fixed issue caused by missing round() in VS before 2013.
> According to [discussion on MSDN](https://social.msdn.microsoft.com/Forums/vstudio/en-US/260e04fc-dd05-4a96-8953-9c6ea1ad62fb/cant-find-stdround-in-cmath), ``round()`` function is not implemented in Microsoft Visual Studio before 2013.

The added lines decides whether applying the implementation according to the version of Visual Studio on one's machine. Thus, it suppress the error caused by the missing identifier. 