### PR TITLE
Expose Error Cross-Covariance in Uncented Kalman Filters

### DIFF
--- a/modules/tracking/include/opencv2/tracking/kalman_filters.hpp
+++ b/modules/tracking/include/opencv2/tracking/kalman_filters.hpp
@@ -81,6 +81,11 @@ public:
     virtual Mat getMeasurementNoiseCov() const = 0;
 
     /**
+    * @return the error cross-covariance matrix.
+    */
+    virtual Mat getErrorCov() const = 0;
+
+    /**
     * @return the current estimate of the state.
     */
     virtual Mat getState() const = 0;

--- a/modules/tracking/src/augmented_unscented_kalman.cpp
+++ b/modules/tracking/src/augmented_unscented_kalman.cpp
@@ -195,6 +195,7 @@ public:
 
     Mat getProcessNoiseCov() const;
     Mat getMeasurementNoiseCov() const;
+    Mat getErrorCov() const;
 
     Mat getState() const;
 
@@ -423,6 +424,11 @@ Mat AugmentedUnscentedKalmanFilterImpl::getProcessNoiseCov() const
 Mat AugmentedUnscentedKalmanFilterImpl::getMeasurementNoiseCov() const
 {
     return measurementNoiseCov.clone();
+}
+
+Mat AugmentedUnscentedKalmanFilterImpl::getErrorCov() const
+{
+    return errorCov.clone();
 }
 
 Mat AugmentedUnscentedKalmanFilterImpl::getState() const

--- a/modules/tracking/src/unscented_kalman.cpp
+++ b/modules/tracking/src/unscented_kalman.cpp
@@ -189,6 +189,7 @@ public:
 //  Get system parameters
     Mat getProcessNoiseCov() const;
     Mat getMeasurementNoiseCov() const;
+    Mat getErrorCov() const;
 
 //  Get the state estimate
     Mat getState() const;
@@ -398,6 +399,11 @@ Mat UnscentedKalmanFilterImpl::getProcessNoiseCov() const
 Mat UnscentedKalmanFilterImpl::getMeasurementNoiseCov() const
 {
     return measurementNoiseCov.clone();
+}
+
+Mat UnscentedKalmanFilterImpl::getErrorCov() const
+{
+    return errorCov.clone();
 }
 
 Mat UnscentedKalmanFilterImpl::getState() const


### PR DESCRIPTION
For some applications it is useful to have an estimate of how uncertain
the specific variable is estimated. This could help to act accordingly
e.g. increase the measurement zone if the current estimate is very
uncertain.