### PR TITLE
revised PredictCollector with set of implementations

### DIFF
--- a/modules/face/include/opencv2/face/predict_collector.hpp
+++ b/modules/face/include/opencv2/face/predict_collector.hpp
@@ -45,9 +45,12 @@ the use of this software, even if advised of the possibility of such damage.
 #ifndef __OPENCV_PREDICT_COLLECTOR_HPP__
 #define __OPENCV_PREDICT_COLLECTOR_HPP__
 #include <cfloat>
+#include <list>
+#include <vector>
+#include <map>
 #include "opencv2/core/cvdef.h"
 #include "opencv2/core/cvstd.hpp"
-#undef emit  //fix for qt
+#undef emit //fix for qt
 namespace cv {
 namespace face {
 //! @addtogroup face
@@ -56,18 +59,40 @@ namespace face {
 */
 class CV_EXPORTS_W PredictCollector {
 protected:
-    double _threshhold;
+    double _threshold;
     int _size;
     int _state;
+    int _excludeLabel;
+    double _distanceKoef;
+    double _minthreshold;
 public:
-    /** @brief creates new predict collector with given threshhold */
-    PredictCollector(double threshhold = DBL_MAX) :_threshhold(threshhold) {};
+    /** @brief creates new predict collector with given threshold */
+    PredictCollector(double threshold = DBL_MAX) {
+        _threshold = threshold;
+        _excludeLabel = 0;
+        _distanceKoef = 1;
+        _minthreshold = -1;
+    }
     CV_WRAP virtual ~PredictCollector() {}
+
     /** @brief called once at start of recognition
     @param size total size of prediction evaluation that recognizer could perform
     @param state user defined send-to-back optional value to allow multi-thread, multi-session or aggregation scenarios
     */
     CV_WRAP virtual void init(const int size, const int state = 0);
+
+    /** @brief called by recognizer prior to emit to decide if prediction require emiting
+    @param label current predicted label
+    @param dist current predicted distance
+    @param state back send state parameter of prediction  session
+    @return true if prediction is valid and required for emiting
+    @note can override given label and distance to another values
+    */
+    CV_WRAP virtual bool defaultFilter(int* label, double* dist, const int state);
+
+    /** @brief extension point for filter - called if base filter executed */
+    CV_WRAP virtual bool filter(int* label, double* dist, const int state);
+
     /** @brief called with every recognition result
     @param label current prediction label
     @param dist current prediction distance (confidence)
@@ -75,6 +100,70 @@ public:
     @return true if recognizer should proceed prediction , false - if recognizer should terminate prediction
     */
     CV_WRAP virtual bool emit(const int label, const double dist, const int state = 0); //not abstract while Python generation require non-abstract class
+
+    /** @brief outer interface method to be called from recognizer
+    @param label current prediction label
+    @param dist current prediction distance (confidence)
+    @param state user defined send-to-back optional value to allow multi-thread, multi-session or aggregation scenarios
+    @note wraps filter and emit calls, not tended to be overriden
+    */
+    CV_WRAP virtual bool collect(int label, double dist, const int state = 0);
+
+    /**
+    @brief get size of prediction
+    ### Description
+    Is set by recognizer and is amount of all available predicts
+    So we can use it to perform statistic collectors before prediction of whole set
+    */
+    CV_WRAP virtual int getSize();
+
+    /** @brief set size of prediction */
+    CV_WRAP virtual void setSize(int size);
+
+    /**
+    @brief get state of prediction
+    ### Description
+    State is a custom value assigned for prediction session, 0 if it's no-state session
+    */
+    CV_WRAP virtual int getState();
+
+    /** @brief set state of prediction */
+    CV_WRAP virtual void setState(int state);
+
+    /**
+    @brief returns currently excluded label, 0 if no set
+    ### Description
+    We require to exclude label if we want to test card in train set against others
+    */
+    CV_WRAP virtual int getExcludeLabel();
+
+    /** @brief set exclude label of prediction */
+    CV_WRAP virtual void setExcludeLabel(int excludeLabel);
+
+    /**
+    @brief returns current distance koeficient (applyed to distance in filter stage)
+    ### Description
+    It's required if we want to predict with distinct algorithms in one session
+    so LBPH, Eigen and Fisher distance are different, but we can provide koef for them to translate to
+    each other (while their distribuition for same train set is close and started from 0)
+    Default 1 koef means that distance is not corrected
+    */
+    CV_WRAP virtual double getDistanceKoef();
+
+    /** @brief set exclude label of prediction */
+    CV_WRAP virtual void setDistanceKoef(double distanceKoef);
+    /**
+    @brief returns current minimal threshold
+    ### Description
+    It's required when we must exclude most closed predictions (for example we
+    search for close but not same faces - usable for mixed set where doubles exists
+    in train collection)
+    */
+    CV_WRAP virtual double getMinThreshold();
+
+    /** @brief set minimal threshold for prediction */
+    CV_WRAP virtual void setMinThreshold(double minthreshold);
+
 };
 
 /** @brief default predict collector that trace minimal distance with treshhold checking (that is default behavior for most predict logic)
@@ -84,20 +173,133 @@ private:
     int _label;
     double _dist;
 public:
-    /** @brief creates new MinDistancePredictCollector with given threshhold */
-    CV_WRAP MinDistancePredictCollector(double threshhold = DBL_MAX) : PredictCollector(threshhold) {
+    /** @brief creates new MinDistancePredictCollector with given threshold */
+    CV_WRAP MinDistancePredictCollector(double threshold = DBL_MAX) : PredictCollector(threshold) {
         _label = -1;
         _dist = DBL_MAX;
     };
     CV_WRAP bool emit(const int label, const double dist, const int state = 0);
-    /** @brief result label, 0 if not found */
+    CV_WRAP bool filter(int* label, double* dist, const int state);
+    /** @brief result label, -1 if not found */
     CV_WRAP int getLabel() const;
     /** @brief result distance (confidence) DBL_MAX if not found */
     CV_WRAP double getDist() const;
     /** @brief factory method to create cv-pointers to MinDistancePredictCollector */
     CV_WRAP static Ptr<MinDistancePredictCollector> create(double threshold = DBL_MAX);
 };
+
+/**
+@brief Collects top N most close predictions
+@note Prevent doubling of same label - if one label is occured twice - most closed distance value will be set
+*/
+class CV_EXPORTS_W TopNPredictCollector : public PredictCollector {
+private:
+    size_t _size;
+    Ptr<std::list<std::pair<int, double> > > _idx;
+public:
+    CV_WRAP TopNPredictCollector(size_t size = 5, double threshold = DBL_MAX) : PredictCollector(threshold) {
+        _size = size;
+        _idx = Ptr<std::list<std::pair<int, double> > >(new std::list<std::pair<int, double> >);
+    };
+    CV_WRAP bool emit(const int label, const double dist, const int state = 0);
+    CV_WRAP bool filter(int* label, double* dist, const int state);
+    Ptr<std::list<std::pair<int, double> > > getResult();
+    CV_WRAP std::vector<std::pair<int, double> > getResultVector(); // pythonable version
+    CV_WRAP static Ptr<TopNPredictCollector> create(size_t size = 5, double threshold = DBL_MAX);
+};
+
+
+/**
+@brief Collects all predict results to single vector
+@note this collector not analyze double labels in emit, it's raw copy of source prediction result,
+remember that filter is still applyed so you can use min/max threshold , distanceKoef and excludeLabel
+*/
+class CV_EXPORTS_W VectorPredictCollector : public PredictCollector {
+private:
+    Ptr<std::vector<std::pair<int, double> > > _idx;
+public:
+    CV_WRAP static const int DEFAULT_SIZE = 5; // top 5 by default
+    CV_WRAP VectorPredictCollector(double threshold = DBL_MAX) : PredictCollector(threshold) {
+        _idx = Ptr<std::vector<std::pair<int, double> > >(new std::vector<std::pair<int, double> >);
+    }
+    CV_WRAP bool emit(const int label, const double dist, const int state = 0);
+    Ptr<std::vector<std::pair<int, double> > > getResult();
+    CV_WRAP std::vector<std::pair<int, double> > getResultVector(); // pythonable version
+    CV_WRAP static Ptr<VectorPredictCollector> create(double threshold = DBL_MAX);
+};
+
+
+/**
+@brief Collects all predict results to single vector
+@note this collector not analyze double labels in emit, it's raw copy of source prediction result,
+remember that filter is still applyed so you can use min/max threshold , distanceKoef and excludeLabel
+*/
+class CV_EXPORTS_W MapPredictCollector : public PredictCollector {
+private:
+    Ptr<std::map<int, double> > _idx;
+public:
+    CV_WRAP static const int DEFAULT_SIZE = 5; // top 5 by default
+    CV_WRAP MapPredictCollector(double threshold = DBL_MAX) : PredictCollector(threshold) {
+        _idx = Ptr<std::map<int, double> >(new std::map<int, double>);
+    }
+    CV_WRAP bool emit(const int label, const double dist, const int state = 0);
+    Ptr<std::map<int, double> > getResult();
+    CV_WRAP std::vector<std::pair<int, double> >  getResultVector(); // pythonable version
+    CV_WRAP static Ptr<MapPredictCollector> create(double threshold = DBL_MAX);
+};
+
+/**
+@brief Collects basic statistic information about prediction
+@note stat predict collector is usefull for determining valid thresholds
+on given trained set, additionally it's required to
+evaluate unified koefs between algorithms
+*/
+class CV_EXPORTS_W StatPredictCollector : public PredictCollector {
+private:
+    double _min;
+    double _max;
+    int _count;
+    double _sum;
+public:
+    CV_WRAP StatPredictCollector(double threshold = DBL_MAX) : PredictCollector(threshold) {
+        _min = DBL_MAX;
+        _max = DBL_MIN;
+        _count = 0;
+        _sum = 0;
+    }
+    CV_WRAP bool emit(const int label, const double dist, const int state = 0);
+    CV_WRAP double getMin();
+    CV_WRAP double getMax();
+    CV_WRAP double getSum();
+    CV_WRAP int getCount();
+    CV_WRAP static Ptr<StatPredictCollector> create(double threshold = DBL_MAX);
+};
+
+/**
+@brief evaluates standard deviation of given prediction session over trained set
+@note in combine with StatPredictCollector can provide statistically based metrices
+for thresholds
+*/
+class CV_EXPORTS_W StdPredictCollector : public PredictCollector {
+private:
+    double _avg;
+    double _n;
+    double _s;
+public:
+    CV_WRAP StdPredictCollector(double threshold = DBL_MAX, double avg = 0) : PredictCollector(threshold) {
+        _avg = avg;
+        _n = 0;
+        _s = 0;
+    }
+    CV_WRAP bool emit(const int label, const double dist, const int state = 0);
+    CV_WRAP double getResult();
+    CV_WRAP static Ptr<StdPredictCollector> create(double threshold = DBL_MAX, double avg = 0);
+};
+
+
+
 //! @}
 }
 }
+
 #endif

--- a/modules/face/src/eigen_faces.cpp
+++ b/modules/face/src/eigen_faces.cpp
@@ -118,7 +118,7 @@ void Eigenfaces::predict(InputArray _src, Ptr<PredictCollector> collector, const
     for (size_t sampleIdx = 0; sampleIdx < _projections.size(); sampleIdx++) {
         double dist = norm(_projections[sampleIdx], q, NORM_L2);
         int label = _labels.at<int>((int)sampleIdx);
-        if (!collector->emit(label, dist, state))return;
+        if (!collector->collect(label, dist, state))return;
     }
 }
 

--- a/modules/face/src/fisher_faces.cpp
+++ b/modules/face/src/fisher_faces.cpp
@@ -138,7 +138,7 @@ void Fisherfaces::predict(InputArray _src, Ptr<PredictCollector> collector, cons
     for (size_t sampleIdx = 0; sampleIdx < _projections.size(); sampleIdx++) {
         double dist = norm(_projections[sampleIdx], q, NORM_L2);
         int label = _labels.at<int>((int)sampleIdx);
-        if (!collector->emit(label, dist, state))return;
+        if (!collector->collect(label, dist, state))return;
     }
 }
 

--- a/modules/face/src/lbph_faces.cpp
+++ b/modules/face/src/lbph_faces.cpp
@@ -403,7 +403,7 @@ void LBPH::predict(InputArray _src, Ptr<PredictCollector> collector, const int s
     for (size_t sampleIdx = 0; sampleIdx < _histograms.size(); sampleIdx++) {
         double dist = compareHist(_histograms[sampleIdx], query, HISTCMP_CHISQR_ALT);
         int label = _labels.at<int>((int)sampleIdx);
-        if (!collector->emit(label, dist, state))return;
+        if (!collector->collect(label, dist, state))return;
     }
 }
 

--- a/modules/face/src/map_predict_collector.cpp
+++ b/modules/face/src/map_predict_collector.cpp
@@ -1,0 +1,86 @@
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+License Agreement
+For Open Source Computer Vision Library
+(3-clause BSD License)
+
+Copyright (C) 2000-2015, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2015, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+#include "opencv2/face/predict_collector.hpp"
+#include "opencv2/core/cvstd.hpp"
+#include <iterator>
+namespace cv {
+namespace face {
+
+CV_WRAP bool MapPredictCollector::emit(const int label, const double dist, const int state)
+{
+    ((void)state);
+    //if already in index check which is closer
+    if (_idx->find(label) != _idx->end()) {
+        double current = (*_idx)[label];
+        if (dist < current) {
+            (*_idx)[label] = dist;
+        }
+    }
+    else {
+        (*_idx)[label] = dist;
+    }
+    return true;
+}
+
+Ptr<std::map<int, double> > MapPredictCollector::getResult()
+{
+    return _idx;
+}
+
+CV_WRAP std::vector<std::pair<int, double> > MapPredictCollector::getResultVector()
+{
+    std::vector<std::pair<int, double> > result;
+    std::copy(_idx->begin(), _idx->end(), std::back_inserter(result));
+    return result;
+}
+
+CV_WRAP Ptr<MapPredictCollector> MapPredictCollector::create(double threshold)
+{
+    return Ptr<MapPredictCollector>(new MapPredictCollector(threshold));
+}
+
+
+
+}
+}

--- a/modules/face/src/mindist_predict_collector.cpp
+++ b/modules/face/src/mindist_predict_collector.cpp
@@ -1,0 +1,76 @@
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+License Agreement
+For Open Source Computer Vision Library
+(3-clause BSD License)
+
+Copyright (C) 2000-2015, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2015, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+#include "opencv2/face/predict_collector.hpp"
+#include "opencv2/core/cvstd.hpp"
+namespace cv {
+namespace face {
+
+bool MinDistancePredictCollector::emit(const int label, const double dist, const int state) {
+    ((void)state);
+    _label = label;
+    _dist = dist;
+    return true;
+}
+
+CV_WRAP bool MinDistancePredictCollector::filter(int* label, double* dist, const int state)
+{
+    ((void)label);
+    ((void)state);
+    return *dist < _dist;
+}
+
+int MinDistancePredictCollector::getLabel() const {
+    return _label;
+}
+
+double MinDistancePredictCollector::getDist() const {
+    return _dist;
+}
+
+Ptr<MinDistancePredictCollector> MinDistancePredictCollector::create(double threshold) {
+    return Ptr<MinDistancePredictCollector>(new MinDistancePredictCollector(threshold));
+}
+
+}
+}

--- a/modules/face/src/stat_predict_collector.cpp
+++ b/modules/face/src/stat_predict_collector.cpp
@@ -1,0 +1,87 @@
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+License Agreement
+For Open Source Computer Vision Library
+(3-clause BSD License)
+
+Copyright (C) 2000-2015, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2015, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+#include "opencv2/face/predict_collector.hpp"
+#include "opencv2/core/cvstd.hpp"
+namespace cv {
+namespace face {
+
+CV_WRAP bool StatPredictCollector::emit(const int label, const double dist, const int state) {
+    ((void)state);
+    ((void)label);
+    _count++;
+    _sum += dist;
+    if (_min > dist) {
+        _min = dist;
+    }
+    if (_max < dist) {
+        _max = dist;
+    }
+    return true;
+}
+CV_WRAP double StatPredictCollector::getMin()
+{
+    return _min;
+}
+
+CV_WRAP double StatPredictCollector::getMax()
+{
+    return _max;
+}
+
+CV_WRAP double StatPredictCollector::getSum()
+{
+    return _sum;
+}
+
+CV_WRAP int StatPredictCollector::getCount()
+{
+    return _count;
+}
+
+CV_WRAP Ptr<StatPredictCollector> StatPredictCollector::create(double threshold) {
+    return Ptr<StatPredictCollector>(new StatPredictCollector(threshold));
+}
+
+}
+}

--- a/modules/face/src/std_predict_collector.cpp
+++ b/modules/face/src/std_predict_collector.cpp
@@ -1,0 +1,65 @@
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+License Agreement
+For Open Source Computer Vision Library
+(3-clause BSD License)
+
+Copyright (C) 2000-2015, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2015, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+#include "opencv2/face/predict_collector.hpp"
+#include "opencv2/core/cvstd.hpp"
+namespace cv {
+namespace face {
+
+CV_WRAP bool StdPredictCollector::emit(const int label, const double dist, const int state) {
+    ((void)state);
+    ((void)label);
+    _s += pow(dist - _avg, 2);
+    _n++;
+    return true;
+}
+CV_WRAP double StdPredictCollector::getResult() {
+    return sqrt(_s / (_n - 1));
+}
+CV_WRAP Ptr<StdPredictCollector> StdPredictCollector::create(double threshold, double avg) {
+    return Ptr<StdPredictCollector>(new StdPredictCollector(threshold, avg));
+}
+
+
+}
+}

--- a/modules/face/src/topn_predict_collector.cpp
+++ b/modules/face/src/topn_predict_collector.cpp
@@ -1,0 +1,109 @@
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+License Agreement
+For Open Source Computer Vision Library
+(3-clause BSD License)
+
+Copyright (C) 2000-2015, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2015, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+#include "opencv2/face/predict_collector.hpp"
+#include "opencv2/core/cvstd.hpp"
+#include <iterator>     // std::back_inserter
+namespace cv {
+namespace face {
+
+CV_WRAP bool TopNPredictCollector::emit(const int label, const double dist, const int state)
+{
+    ((void)state);
+    std::pair<int, double> p = std::make_pair(label, dist);
+    if (_idx->size() == 0 || p.second <= _idx->front().second) {
+        _idx->push_front(p);
+    } else if (p.second >= _idx->back().second) {
+        _idx->push_back(p);
+    }
+    else {
+        typedef std::list<std::pair<int,double> >::iterator it_type;
+        for (it_type i = _idx->begin(); i != _idx->end(); i++) {
+            if (p.second <= i->second) {
+                _idx->insert(i, p);
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+CV_WRAP bool TopNPredictCollector::filter(int * label, double * dist, const int state)
+{
+    ((void)state);
+    if (_idx->size() < _size)return true; //not full - can insert;
+    if (*dist >= _idx->back().second)return false; //too far distance
+    for (std::list<std::pair<int, double> >::iterator it = _idx->begin(); it != _idx->end(); ++it) {
+        if (it->first == *label) {
+            if (it->second <= *dist) {
+                return false; //has more close
+            }
+            else {
+                _idx->erase(it);
+                return true; //no more require pop_back
+            }
+        }
+    }
+    _idx->pop_back();
+    return true;
+}
+
+CV_WRAP Ptr<std::list<std::pair<int, double> > > TopNPredictCollector::getResult()
+{
+    return _idx;
+}
+
+CV_WRAP std::vector<std::pair<int, double> > TopNPredictCollector::getResultVector()
+{
+    std::vector<std::pair<int, double> > result;
+    std::copy(_idx->begin(), _idx->end(), std::back_inserter(result));
+    return result;
+}
+
+CV_WRAP Ptr<TopNPredictCollector> TopNPredictCollector::create(size_t size, double threshold)
+{
+    return Ptr<TopNPredictCollector>(new TopNPredictCollector(size, threshold));
+}
+
+}
+}

--- a/modules/face/src/vector_predict_collector.cpp
+++ b/modules/face/src/vector_predict_collector.cpp
@@ -1,0 +1,71 @@
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+License Agreement
+For Open Source Computer Vision Library
+(3-clause BSD License)
+
+Copyright (C) 2000-2015, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2015, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the names of the copyright holders nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+#include "opencv2/face/predict_collector.hpp"
+#include "opencv2/core/cvstd.hpp"
+namespace cv {
+namespace face {
+CV_WRAP bool VectorPredictCollector::emit(const int label, const double dist, const int state)
+{
+    ((void)state);
+    _idx->push_back(std::pair<int, double>(label, dist));
+    return true;
+}
+Ptr<std::vector<std::pair<int, double> > > VectorPredictCollector::getResult()
+{
+    return _idx;
+}
+
+CV_WRAP std::vector<std::pair<int, double> > VectorPredictCollector::getResultVector()
+{
+    return (*_idx);
+}
+
+CV_WRAP Ptr<VectorPredictCollector> VectorPredictCollector::create(double threshold)
+{
+    return Ptr<VectorPredictCollector>(new VectorPredictCollector(threshold));
+}
+
+
+}
+}


### PR DESCRIPTION
In prolongation for issue #401 and PR #402
Ported from real project.
Improves previously provided #402 on following manner: filtering, unification, better class model, collector set for buffering set of result and for statistical threshold metric count. 

* PredictCollector base class remaked:
	* templated `collect` method 
	* `distanceKoef` to allow compare results of distinct algorithms
	* `minThreshold` to allow filter out duplicates and keep only similar responses
	* `excludeLabel` to allow cross check images in train set without checking with self
	* `defaultFilter` that checks not just minthresh but maxthresh, guard label and state, applys `distanceKoef` to dist
	* `filter` method for overload to provide cusom filtering logic (non-filtered predicts will not send to emit)
	* filters can overwrite label/distance pair
	* `emit` method now not require to perform any checkings and it's implementation should just somehow store prediction in internal result (mapper)
* `PredictCollector` implementations added:
	* `MinDistancePredictCollector` - default for existed API - search for single search result
	* `TopNPredictCollector` - collects top N (5 by default) most closes result, `std::list` returned, sorted
	* `VectorPredictCollector` - stores all predict results in `std::vector` (for #359 usage), no double checkings - raw results
	* `MapPredictCollector` - stores all predict results in `std::map` where label is key - if doublers - most closed distance will be value
	* `StatPredictCollector` - allows collect base statistics about image prediction over train set (min, max, sum, count, avg) - usefull to determine best thresholds for certain task/train set and account koefs to unify different algorithm response
	* `StdPredictCollector` - collects standard diviation with given AVG (can be got from StatPredictCollector ) - usefull to determine best thresholds for certain task/train set
	