### PR TITLE
opencv_xfeatures2d: CUDA SURF: check if __CUDA_ARCH__ is defined before comparing it

### DIFF
--- a/modules/xfeatures2d/src/cuda/surf.cu
+++ b/modules/xfeatures2d/src/cuda/surf.cu
@@ -150,7 +150,7 @@ namespace cv { namespace cuda { namespace device
 
         template <int N> __device__ float icvCalcHaarPatternSum(const float src[][5], int oldSize, int newSize, int y, int x)
         {
-        #if __CUDA_ARCH__ && __CUDA_ARCH__ >= 200
+        #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 200
             typedef double real_t;
         #else
             typedef float  real_t;
@@ -284,7 +284,7 @@ namespace cv { namespace cuda { namespace device
         __global__ void icvFindMaximaInLayer(const PtrStepf det, const PtrStepf trace, int4* maxPosBuffer,
             unsigned int* maxCounter)
         {
-            #if __CUDA_ARCH__ && __CUDA_ARCH__ >= 110
+            #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 110
 
             extern __shared__ float N9[];
 
@@ -407,7 +407,7 @@ namespace cv { namespace cuda { namespace device
             float* featureX, float* featureY, int* featureLaplacian, int* featureOctave, float* featureSize, float* featureHessian,
             unsigned int* featureCounter)
         {
-            #if __CUDA_ARCH__ && __CUDA_ARCH__ >= 110
+            #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 110
 
             const int4 maxPos = maxPosBuffer[blockIdx.x];
 
@@ -592,7 +592,7 @@ namespace cv { namespace cuda { namespace device
 
             float bestx = 0, besty = 0, best_mod = 0;
 
-        #if __CUDA_ARCH__ >= 200
+        #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 200
             #pragma unroll
         #endif
             for (int i = 0; i < 18; ++i)


### PR DESCRIPTION
Changed statements of type "#if __CUDA_ARCH__ >= 200" to
"#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 200" in order to
avoid warnings about __CUDA_ARCH__ being undefined.