### PR TITLE
Bugfix & Enhance: Fix close() issue and add H5_GETCHUNKDIMS option.

### DIFF
--- a/modules/hdf/include/opencv2/hdf/hdf5.hpp
+++ b/modules/hdf/include/opencv2/hdf/hdf5.hpp
@@ -63,7 +63,7 @@ public:
 
     CV_WRAP enum
     {
-      H5_UNLIMITED = -1, H5_NONE = -1, H5_GETDIMS = 100, H5_GETMAXDIMS = 101,
+      H5_UNLIMITED = -1, H5_NONE = -1, H5_GETDIMS = 100, H5_GETMAXDIMS = 101, H5_GETCHUNKDIMS = 102,
     };
 
     virtual ~HDF5() {}
@@ -278,7 +278,9 @@ public:
     actual dataset dimensions. Using H5_GETMAXDIM flag will get maximum allowed dimension which normally match
     actual dataset dimension but can hold H5_UNLIMITED value if dataset was prepared in **unlimited** mode on
     some of its dimension. It can be useful to check existing dataset dimensions before overwrite it as whole or subset.
-    Trying to write with oversized source data into dataset target will thrown exception.
+    Trying to write with oversized source data into dataset target will thrown exception. The H5_GETCHUNKDIMS will
+    return the dimension of chunk if dataset was created with chunking options otherwise returned vector size
+    will be zero.
      */
     CV_WRAP virtual vector<int> dsgetsize( String dslabel, int dims_flag = HDF5::H5_GETDIMS ) const = 0;
 
@@ -488,7 +490,8 @@ public:
     Using H5_GETMAXDIM flag will get maximum allowed dimension which normally match actual dataset dimension but can hold
     H5_UNLIMITED value if dataset was prepared in **unlimited** mode. It can be useful to check existing dataset dimension
     before overwrite it as whole or subset. Trying to write with oversized source data into dataset target will thrown
-    exception.
+    exception. The H5_GETCHUNKDIMS will return the dimension of chunk if dataset was created with chunking options otherwise
+    returned vector size will be zero.
      */
     CV_WRAP virtual int kpgetsize( String kplabel, int dims_flag = HDF5::H5_GETDIMS ) const = 0;
 


### PR DESCRIPTION
This PR address:

(1) Fix annoying ```close()``` issue when multiple datasets are opened at same time. Invoking ```close()``` **should not** alter other datasets status !

* It fix this scenario when two sets are opened at same time like below:
```
  cv::Ptr<cv::hdf::HDF5> h5io = cv::hdf::open( "test1.h5" );
  cv::Ptr<cv::hdf::HDF5> h5iw = cv::hdf::open( "test2.h5" );
  h5io->close();
  h5iw->close();
HDF5-DIAG: Error detected in HDF5 (1.8.15-patch1) thread 0:
  #000: ../../src/H5F.c line 781 in H5Fclose(): invalid file identifier
    major: Invalid arguments to routine
    minor: Inappropriate type
```
*  First ```h5io->dsclose()``` instance force booth datasets to close due to code bug caused by superfluous call to HDF's internal *H5close()* that shutdown all open sessions: https://github.com/cbalint13/opencv_contrib/commit/f468c1a634e4756d811a515ab96832b63d3af24f#diff-af5f4404415cf174c84ecdcc91e6cea1L286 .

* File status in ```open()``` is updated to reflect all possible states: https://github.com/cbalint13/opencv_contrib/commit/a01002f62b32293c44f20effbba6ff3f55d97901#diff-af5f4404415cf174c84ecdcc91e6cea1R273

(2) Add possibility to get properties *about chunk dimensions* not only about size or maxsize. Introduced the new **H5_GETCHUNKDIMS** flag among H5_GETDIMS, H5_GETMAXDIMS. This is an enhanchement and is documented too.