### PR TITLE
Use correct test for existence of CPU's POPCNT feature

### DIFF
--- a/modules/stereo/include/opencv2/stereo/matching.hpp
+++ b/modules/stereo/include/opencv2/stereo/matching.hpp
@@ -171,10 +171,15 @@ namespace cv
                                 j2 = (0 > j - d) ? (0) : (j - d);
                                 xorul = left[(iwj)] ^ right[(iw + j2)];
 #if CV_POPCNT
-                                c[(iwj)* (v + 1) + d] = (short)_mm_popcnt_u32(xorul);
-#else
-                                c[(iwj)* (v + 1) + d] = (short)(hammLut[xorul & MASK] + hammLut[(xorul >> 16) & MASK]);
+                                if (checkHardwareSupport(CV_CPU_POPCNT))
+                                {
+                                    c[(iwj)* (v + 1) + d] = (short)_mm_popcnt_u32(xorul);
+                                }
+                                else
 #endif
+                                {
+                                    c[(iwj)* (v + 1) + d] = (short)(hammLut[xorul & MASK] + hammLut[(xorul >> 16) & MASK]);
+                                }
                             }
                         }
                     }

--- a/modules/stereo/include/opencv2/stereo/matching.hpp
+++ b/modules/stereo/include/opencv2/stereo/matching.hpp
@@ -170,7 +170,7 @@ namespace cv
                             {
                                 j2 = (0 > j - d) ? (0) : (j - d);
                                 xorul = left[(iwj)] ^ right[(iw + j2)];
-#if CV_SSE4_1
+#if CV_POPCNT
                                 c[(iwj)* (v + 1) + d] = (short)_mm_popcnt_u32(xorul);
 #else
                                 c[(iwj)* (v + 1) + d] = (short)(hammLut[xorul & MASK] + hammLut[(xorul >> 16) & MASK]);


### PR DESCRIPTION
Existence of POPCNT is indicated by `CV_POPCNT`, not `CV_SSE4_1`. Fix for [https://github.com/Itseez/opencv_contrib/issues/513].