### PR TITLE
MSVC 2008 Python fixes

### DIFF
--- a/modules/text/src/ocr_beamsearch_decoder.cpp
+++ b/modules/text/src/ocr_beamsearch_decoder.cpp
@@ -566,7 +566,7 @@ OCRBeamSearchClassifierCNN::OCRBeamSearchClassifierCNN (const string& filename)
 
     nr_feature = weights.rows;
     nr_class   = weights.cols;
-    patch_size  = (int)sqrt(kernels.cols);
+    patch_size  = (int)sqrt((float)kernels.cols);
     window_size = 4*patch_size;
     step_size   = 4;
     quad_size   = 12;

--- a/modules/text/src/ocr_hmm_decoder.cpp
+++ b/modules/text/src/ocr_hmm_decoder.cpp
@@ -982,7 +982,7 @@ OCRHMMClassifierCNN::OCRHMMClassifierCNN (const string& filename)
 
     nr_feature  = weights.rows;
     nr_class    = weights.cols;
-    patch_size  = (int)sqrt(kernels.cols);
+    patch_size  = (int)sqrt((float)kernels.cols);
     // algorithm internal parameters
     window_size = 32;
     num_quads   = 25;

--- a/modules/tracking/src/trackerKCF.cpp
+++ b/modules/tracking/src/trackerKCF.cpp
@@ -666,7 +666,7 @@ namespace cv{
     for(int i=0;i<patch_data.rows;i++){
       for(int j=0;j<patch_data.cols;j++){
         pixel=patch_data.at<Vec3b>(i,j);
-        index=(unsigned)(floor(pixel[2]/8)+32*floor(pixel[1]/8)+32*32*floor(pixel[0]/8));
+        index=(unsigned)(floor((float)pixel[2]/8)+32*floor((float)pixel[1]/8)+32*32*floor((float)pixel[0]/8));
 
         //copy the values
         for(int _k=0;_k<10;_k++){


### PR DESCRIPTION
Just a couple of commits adding simple casts that enable building of OpenCV 3.1 for Python 2.7 (which implicitly requires MSVC 2008).