### PR TITLE
ERFilter python bindings

### DIFF
--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -225,7 +225,7 @@ classifier uses all the features calculated in the first stage and the following
 features: hole area ratio, convex hull ratio, and number of outer inflexion points.
  */
 CV_EXPORTS_W Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb,
-                                                  float minProbability = 0.3);
+                                                  float minProbability = (float)0.3);
 
 
 /** @brief Allow to implicitly load the default classifier when creating an ERFilter object.

--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -264,7 +264,7 @@ channels (Grad) are used in order to obtain high localization recall. This imple
 provides an alternative combination of red (R), green (G), blue (B), lightness (L), and gradient
 magnitude (Grad).
  */
-CV_EXPORTS void computeNMChannels(InputArray _src, OutputArrayOfArrays _channels, int _mode = ERFILTER_NM_RGBLGrad);
+CV_EXPORTS_W void computeNMChannels(InputArray _src, CV_OUT OutputArrayOfArrays _channels, int _mode = ERFILTER_NM_RGBLGrad);
 
 
 
@@ -323,6 +323,13 @@ CV_EXPORTS void erGrouping(InputArray img, InputArrayOfArrays channels,
                                            int method = ERGROUPING_ORIENTATION_HORIZ,
                                            const std::string& filename = std::string(),
                                            float minProbablity = 0.5);
+
+CV_EXPORTS_W void erGrouping(InputArray image, InputArray channel,
+                                           std::vector<std::vector<Point> > regions,
+                                           CV_OUT std::vector<Rect> &groups_rects,
+                                           int method = ERGROUPING_ORIENTATION_HORIZ,
+                                           const String& filename = String(),
+                                           float minProbablity = (float)0.5);
 
 /** @brief Converts MSER contours (vector\<Point\>) to ERStat regions.
 

--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -115,7 +115,7 @@ public:
 
 Extracts the component tree (if needed) and filter the extremal regions (ER's) by using a given classifier.
  */
-class CV_EXPORTS ERFilter : public Algorithm
+class CV_EXPORTS_W ERFilter : public Algorithm
 {
 public:
 
@@ -124,7 +124,7 @@ public:
     By doing it we hide SVM, Boost etc. Developers can provide their own classifiers to the
     ERFilter algorithm.
      */
-    class CV_EXPORTS Callback
+    class CV_EXPORTS_W Callback
     {
     public:
         virtual ~Callback() { }
@@ -207,7 +207,7 @@ the probability P(er|character) are selected (if the local maximum of the probab
 global limit pmin and the difference between local maximum and local minimum is greater than
 minProbabilityDiff).
  */
-CV_EXPORTS Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb,
+CV_EXPORTS_W Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb,
                                                   int thresholdDelta = 1, float minArea = 0.00025,
                                                   float maxArea = 0.13, float minProbability = 0.4,
                                                   bool nonMaxSuppression = true,
@@ -224,7 +224,7 @@ non-character classes using more informative but also more computationally expen
 classifier uses all the features calculated in the first stage and the following additional
 features: hole area ratio, convex hull ratio, and number of outer inflexion points.
  */
-CV_EXPORTS Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb,
+CV_EXPORTS_W Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb,
                                                   float minProbability = 0.3);
 
 
@@ -234,7 +234,7 @@ CV_EXPORTS Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb,
 
 returns a pointer to ERFilter::Callback.
  */
-CV_EXPORTS Ptr<ERFilter::Callback> loadClassifierNM1(const std::string& filename);
+CV_EXPORTS_W Ptr<ERFilter::Callback> loadClassifierNM1(const String& filename);
 
 /** @brief Allow to implicitly load the default classifier when creating an ERFilter object.
 
@@ -242,7 +242,7 @@ CV_EXPORTS Ptr<ERFilter::Callback> loadClassifierNM1(const std::string& filename
 
 returns a pointer to ERFilter::Callback.
  */
-CV_EXPORTS Ptr<ERFilter::Callback> loadClassifierNM2(const std::string& filename);
+CV_EXPORTS_W Ptr<ERFilter::Callback> loadClassifierNM2(const String& filename);
 
 
 //! computeNMChannels operation modes
@@ -342,6 +342,9 @@ An example of MSERsToERStats in use can be found in the text detection webcam_de
  */
 CV_EXPORTS void MSERsToERStats(InputArray image, std::vector<std::vector<Point> > &contours,
                                std::vector<std::vector<ERStat> > &regions);
+
+// Utility funtion for scripting
+CV_EXPORTS_W void detectRegions(InputArray image, const Ptr<ERFilter>& er_filter1, const Ptr<ERFilter>& er_filter2, CV_OUT std::vector< std::vector<Point> >& regions);
 
 //! @}
 

--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -208,10 +208,10 @@ global limit pmin and the difference between local maximum and local minimum is 
 minProbabilityDiff).
  */
 CV_EXPORTS_W Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb,
-                                                  int thresholdDelta = 1, float minArea = 0.00025,
-                                                  float maxArea = 0.13, float minProbability = 0.4,
+                                                  int thresholdDelta = 1, float minArea = (float)0.00025,
+                                                  float maxArea = (float)0.13, float minProbability = (float)0.4,
                                                   bool nonMaxSuppression = true,
-                                                  float minProbabilityDiff = 0.1);
+                                                  float minProbabilityDiff = (float)0.1);
 
 /** @brief Create an Extremal Region Filter for the 2nd stage classifier of N&M algorithm [Neumann12].
 

--- a/modules/text/samples/detect_er_chars.py
+++ b/modules/text/samples/detect_er_chars.py
@@ -7,13 +7,13 @@ import cv2
 import numpy as np
 from matplotlib import pyplot as plt
 
-print '\ndetect_er_chars.py'
-print '       A simple demo script using the Extremal Region Filter algorithm described in:'
-print '       Neumann L., Matas J.: Real-Time Scene Text Localization and Recognition, CVPR 2012\n'
+print('\ndetect_er_chars.py')
+print('       A simple demo script using the Extremal Region Filter algorithm described in:')
+print('       Neumann L., Matas J.: Real-Time Scene Text Localization and Recognition, CVPR 2012\n')
 
 
 if (len(sys.argv) < 2):
-  print ' (ERROR) You must call this script with an argument (path_to_image_to_be_processed)\n'
+  print(' (ERROR) You must call this script with an argument (path_to_image_to_be_processed)\n')
   quit()
 
 pathname = os.path.dirname(sys.argv[0])

--- a/modules/text/samples/detect_er_chars.py
+++ b/modules/text/samples/detect_er_chars.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+
+import sys
+import os
+
+import cv2
+import numpy as np
+from matplotlib import pyplot as plt
+
+print '\ndetect_er_chars.py'
+print '       A simple demo script using the Extremal Region Filter algorithm described in:'
+print '       Neumann L., Matas J.: Real-Time Scene Text Localization and Recognition, CVPR 2012\n'
+
+
+if (len(sys.argv) < 2):
+  print ' (ERROR) You must call this script with an argument (path_to_image_to_be_processed)\n'
+  quit()
+
+pathname = os.path.dirname(sys.argv[0])
+
+img  = cv2.imread(str(sys.argv[1]))
+gray = cv2.imread(str(sys.argv[1]),0)
+
+erc1 = cv2.text.loadClassifierNM1(pathname+'/trained_classifierNM1.xml')
+er1 = cv2.text.createERFilterNM1(erc1)
+
+erc2 = cv2.text.loadClassifierNM2(pathname+'/trained_classifierNM2.xml')
+er2 = cv2.text.createERFilterNM2(erc2)
+
+regions = cv2.text.detectRegions(gray,er1,er2)
+
+#Visualization
+rects = [cv2.boundingRect(p.reshape(-1, 1, 2)) for p in regions]
+for rect in rects:
+  cv2.rectangle(img, rect[0:2], (rect[0]+rect[2],rect[1]+rect[3]), (0, 0, 255), 2)
+img = img[:,:,::-1] #flip the colors dimension from BGR to RGB
+plt.imshow(img)
+plt.xticks([]), plt.yticks([])  # to hide tick values on X and Y axis
+plt.show()

--- a/modules/text/samples/textdetection.py
+++ b/modules/text/samples/textdetection.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+
+import sys
+import os
+
+import cv2
+import numpy as np
+from matplotlib import pyplot as plt
+
+print('\ntextdetection.py')
+print('       A demo script of the Extremal Region Filter algorithm described in:')
+print('       Neumann L., Matas J.: Real-Time Scene Text Localization and Recognition, CVPR 2012\n')
+
+
+if (len(sys.argv) < 2):
+  print(' (ERROR) You must call this script with an argument (path_to_image_to_be_processed)\n')
+  quit()
+
+pathname = os.path.dirname(sys.argv[0])
+
+
+img      = cv2.imread(str(sys.argv[1]))
+vis      = img.copy() # for visualization 
+
+
+# Extract channels to be processed individually
+channels = cv2.text.computeNMChannels(img)
+# Append negative channels to detect ER- (bright regions over dark background)
+cn = len(channels)-1
+for c in range(0,cn):
+  channels.append((255-channels[c]))
+
+# Apply the default cascade classifier to each independent channel (could be done in parallel)
+print("Extracting Class Specific Extremal Regions from "+str(len(channels))+" channels ...")
+print("    (...) this may take a while (...)")
+for channel in channels:
+
+  erc1 = cv2.text.loadClassifierNM1(pathname+'/trained_classifierNM1.xml')
+  er1 = cv2.text.createERFilterNM1(erc1,16,0.00015,0.13,0.2,True,0.1)
+
+  erc2 = cv2.text.loadClassifierNM2(pathname+'/trained_classifierNM2.xml')
+  er2 = cv2.text.createERFilterNM2(erc2,0.5)
+
+  regions = cv2.text.detectRegions(channel,er1,er2)
+
+  rects = cv2.text.erGrouping(img,channel,[r.tolist() for r in regions])
+  #rects = cv2.text.erGrouping(img,gray,[x.tolist() for x in regions], cv2.text.ERGROUPING_ORIENTATION_ANY,'../../GSoC2014/opencv_contrib/modules/text/samples/trained_classifier_erGrouping.xml',0.5)
+
+  #Visualization
+  for r in range(0,np.shape(rects)[0]):
+    rect = rects[r]
+    cv2.rectangle(vis, (rect[0],rect[1]), (rect[0]+rect[2],rect[1]+rect[3]), (0, 255, 255), 2)
+
+
+#Visualization
+vis = vis[:,:,::-1] #flip the colors dimension from BGR to RGB
+plt.imshow(vis)
+plt.xticks([]), plt.yticks([])  # to hide tick values on X and Y axis
+plt.show()

--- a/modules/text/samples/textdetection.py
+++ b/modules/text/samples/textdetection.py
@@ -20,7 +20,8 @@ pathname = os.path.dirname(sys.argv[0])
 
 
 img      = cv2.imread(str(sys.argv[1]))
-vis      = img.copy() # for visualization 
+# for visualization
+vis      = img.copy()
 
 
 # Extract channels to be processed individually


### PR DESCRIPTION
first time I try to expose this code to Python. I did it by looking how other modules do it. Since ERStat is a kind of "low-level" struct with no much interest for final users I have wrapped all the process in a single function cv2.text.detectRegions() which returns a vector< vector<Point> > with all regions. (Similarly as MSER function does).

Provided sample script detect_er_chars.py works ok for me in Linux (Ubuntu 15). 

@vpisarev can you please take a look at it? thnkx!