### PR TITLE
Add option to create GridBoard starting at user-specified marker id

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -268,16 +268,16 @@ class CV_EXPORTS_W GridBoard : public Board {
      * @param markersX number of markers in X direction
      * @param markersY number of markers in Y direction
      * @param markerLength marker side length (normally in meters)
-     * @param markerSeparation separation between two markers (same unit than markerLenght)
-     * @param dictionary dictionary of markers indicating the type of markers.
-     * The first markersX*markersY markers in the dictionary are used.
+     * @param markerSeparation separation between two markers (same unit as markerLength)
+     * @param dictionary dictionary of markers indicating the type of markers
+     * @param firstMarker id of first marker in dictionary to use on board.
      * @return the output GridBoard object
      *
      * This functions creates a GridBoard object given the number of markers in each direction and
      * the marker size and marker separation.
      */
     CV_WRAP static Ptr<GridBoard> create(int markersX, int markersY, float markerLength,
-                                         float markerSeparation, Ptr<Dictionary> &dictionary);
+                                         float markerSeparation, Ptr<Dictionary> &dictionary, int firstMarker = 0);
 
     /**
       *

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1329,11 +1329,10 @@ void GridBoard::draw(Size outSize, OutputArray _img, int marginSize, int borderB
 }
 
 
-
 /**
  */
 Ptr<GridBoard> GridBoard::create(int markersX, int markersY, float markerLength, float markerSeparation,
-                            Ptr<Dictionary> &dictionary) {
+                            Ptr<Dictionary> &dictionary, int firstMarker) {
 
     CV_Assert(markersX > 0 && markersY > 0 && markerLength > 0 && markerSeparation > 0);
 
@@ -1351,7 +1350,7 @@ Ptr<GridBoard> GridBoard::create(int markersX, int markersY, float markerLength,
 
     // fill ids with first identifiers
     for(unsigned int i = 0; i < totalMarkers; i++) {
-        res->ids[i] = i;
+        res->ids[i] = i + firstMarker;
     }
 
     // calculate Board objPoints


### PR DESCRIPTION
For our application, we want to be able to make a number of uniquely-identifiable boards. I added an optional parameter to GridBoard::create to make this possible. Omitting the optional parameter reproduces existing behavior.