### PR TITLE
Compiler error for VC10 removed

### DIFF
--- a/modules/line_descriptor/perf/perf_matching.cpp
+++ b/modules/line_descriptor/perf/perf_matching.cpp
@@ -101,7 +101,7 @@ uchar invertSingleBits( uchar dividend_char, int numBits )
   /* reconvert to decimal */
   uchar result = 0;
   for ( int i = (int) bin_vector.size() - 1; i >= 0; i-- )
-    result += (uchar) ( bin_vector[i] * pow( 2, i ) );
+    result += (uchar) ( bin_vector[i] * pow( 2.0, i ) );
 
   return result;
 }

--- a/modules/line_descriptor/perf/perf_matching.cpp
+++ b/modules/line_descriptor/perf/perf_matching.cpp
@@ -101,7 +101,7 @@ uchar invertSingleBits( uchar dividend_char, int numBits )
   /* reconvert to decimal */
   uchar result = 0;
   for ( int i = (int) bin_vector.size() - 1; i >= 0; i-- )
-    result += (uchar) ( bin_vector[i] * pow( 2.0, i ) );
+    result += (uchar) ( bin_vector[i] * ( 1 << i ) );
 
   return result;
 }

--- a/modules/line_descriptor/test/test_matcher_regression.cpp
+++ b/modules/line_descriptor/test/test_matcher_regression.cpp
@@ -123,7 +123,7 @@ uchar CV_BinaryDescriptorMatcherTest::invertSingleBits( uchar dividend_char, int
   /* reconvert to decimal */
   uchar result = 0;
   for ( int i = (int) bin_vector.size() - 1; i >= 0; i-- )
-    result += (uchar) ( bin_vector[i] * pow( 2.0, i ) );
+    result += (uchar) ( bin_vector[i] * ( 1 << i ) );
 
   return result;
 }

--- a/modules/line_descriptor/test/test_matcher_regression.cpp
+++ b/modules/line_descriptor/test/test_matcher_regression.cpp
@@ -123,7 +123,7 @@ uchar CV_BinaryDescriptorMatcherTest::invertSingleBits( uchar dividend_char, int
   /* reconvert to decimal */
   uchar result = 0;
   for ( int i = (int) bin_vector.size() - 1; i >= 0; i-- )
-    result += (uchar) ( bin_vector[i] * pow( 2, i ) );
+    result += (uchar) ( bin_vector[i] * pow( 2.0, i ) );
 
   return result;
 }


### PR DESCRIPTION
	modified:   modules/line_descriptor/perf/perf_matching.cpp
	modified:   modules/line_descriptor/test/test_matcher_regression.cpp

If have observed two compiler errors when compiling with MS Visual Studio 2010. The 
reason is the function  pow( 2, i ) . The first argument should not be an integer but rather 
a float or double number. For this reason, I have replaced this function by  pow( 2.0, i ) ,
I have done this in two cases. The changes should not have any effect on the calculation.