### PR TITLE
One of 2 includes of xobjdetect.hpp removed

### DIFF
--- a/modules/xobjdetect/src/precomp.hpp
+++ b/modules/xobjdetect/src/precomp.hpp
@@ -76,6 +76,5 @@ the use of this software, even if advised of the possibility of such damage.
 #include "lbpfeatures.h"
 #include "waldboost.hpp"
 #include "wbdetector.hpp"
-#include <opencv2/xobjdetect.hpp>
 
 #endif /* __OPENCV_XOBJDETECT_PRECOMP_HPP__ */


### PR DESCRIPTION
For some unknown reason xobjdetect.hpp is included twice. 