### PR TITLE
roiSelector platform dependency bug

### DIFF
--- a/modules/tracking/src/roiSelector.cpp
+++ b/modules/tracking/src/roiSelector.cpp
@@ -107,8 +107,10 @@ namespace cv {
     // select the object
     setMouseCallback( windowName, mouseHandler, (void *)&selectorParams );
 
+    // extract lower 8 bits for scancode comparison
+    unsigned int key_ = key & 0xFF;
     // end selection process on SPACE (32) ESC (27) or ENTER (13)
-    while(!(key==32 || key==27 || key==13)){
+    while(!(key_==32 || key_==27 || key_==13)){
       // draw the selected object
       rectangle(
         selectorParams.image,


### PR DESCRIPTION
Added lower 8-bit comparison for key presses.

Fixes https://github.com/Itseez/opencv_contrib/issues/548