### PR TITLE
no trailing rect capture on escape

### DIFF
--- a/modules/tracking/src/roiSelector.cpp
+++ b/modules/tracking/src/roiSelector.cpp
@@ -161,8 +161,9 @@ namespace cv {
     printf("Finish the selection process by pressing ESC button!\n" );
 
     // while key is not ESC (27)
-    while(key!=27){
+    for(;;) {
       temp=select(windowName, img, true, fromCenter);
+      if(key==27) break;
       if(temp.width>0 && temp.height>0)
         box.push_back(temp);
     }


### PR DESCRIPTION
- no ambiguity about last rect (complement #459 and bd20972847615184811553768e2d35b3c4c78451)
also [answer self request](https://github.com/Itseez/opencv_contrib/pull/539#commitcomment-16864422)