### PR TITLE
Allow vector<Mat> raster bands for SEEDS.

### DIFF
--- a/modules/ximgproc/src/seeds.cpp
+++ b/modules/ximgproc/src/seeds.cpp
@@ -375,7 +375,31 @@ void SuperpixelSEEDSImpl::initImageBins<float>(const Mat& img, int)
 
 void SuperpixelSEEDSImpl::initImage(InputArray img)
 {
-    Mat src = img.getMat();
+    Mat src;
+
+    if ( img.isMat() )
+    {
+      // get Mat
+      src = img.getMat();
+
+      // image should be valid
+      CV_Assert( !src.empty() );
+    }
+    else if ( img.isMatVector() )
+    {
+      vector<Mat> vec;
+      // get vector Mat
+      img.getMatVector( vec );
+
+      // array should be valid
+      CV_Assert( !vec.empty() );
+
+      // merge into Mat
+      merge( vec, src );
+    }
+    else
+      CV_Error( Error::StsInternal, "Invalid InputArray." );
+
     int depth = src.depth();
     seeds_current_level = seeds_nr_levels - 2;
     forwardbackward = true;


### PR DESCRIPTION
This tiny patch allows to pass image in ```std::vector<cv::Mat>``` not only in ```cv::Mat``` thus enabling additional raster image layout for SEEDS superpixles algorithm. 

It is enhancement not bugfix, some reasons:

* It is useful e.g. for very large satellite imagery where stack of  2d ```cv::Mat``` rasterbands layout is much more memory friendly since read of large bands happen in sequential way and bands are just concatenated at the end into ```std::vector``` array.

* LSC and SLIC already handle booth ```std::vector<cv::Mat>``` not only in ```cv::Mat``` layouts, so expecting SEEDS too. In fact ```std::vector<cv::Mat>``` is the internal default schema for these two since each bands (it can be multispectral) represents a separate band matrix.