### PR TITLE
add model location info

### DIFF
--- a/modules/ximgproc/samples/structured_edge_detection.cpp
+++ b/modules/ximgproc/samples/structured_edge_detection.cpp
@@ -1,3 +1,9 @@
+/**************************************************************************************
+The structered edge demo requires you to provide a model.
+This model can be found at the opencv_extra repository on Github on the following link:
+https://github.com/Itseez/opencv_extra/blob/master/testdata/cv/ximgproc/model.yml.gz
+***************************************************************************************/
+
 #include <opencv2/ximgproc.hpp>
 #include "opencv2/highgui.hpp"
 #include "opencv2/core/utility.hpp"


### PR DESCRIPTION
The exact model location was missing and thus people do not know how to run the sample.
See https://github.com/Itseez/opencv_contrib/issues/654 