### PR TITLE
Fix sign() macro redefinition compile-time error

### DIFF
--- a/modules/tracking/include/opencv2/tracking/onlineMIL.hpp
+++ b/modules/tracking/include/opencv2/tracking/onlineMIL.hpp
@@ -54,8 +54,6 @@ namespace cv
 //TODO based on the original implementation
 //http://vision.ucsd.edu/~bbabenko/project_miltrack.shtml
 
-#define  sign(s)  ((s > 0 ) ? 1 : ((s<0) ? -1 : 0))
-
 class ClfOnlineStump;
 
 class CV_EXPORTS ClfMilBoost

--- a/modules/tracking/src/onlineMIL.cpp
+++ b/modules/tracking/src/onlineMIL.cpp
@@ -42,6 +42,8 @@
 #include "precomp.hpp"
 #include "opencv2/tracking/onlineMIL.hpp"
 
+#define  sign(s)  ((s > 0 ) ? 1 : ((s<0) ? -1 : 0))
+
 template<class T> class SortableElementRev
 {
  public:


### PR DESCRIPTION
Fixes #618 as suggested by @alalek