### PR TITLE
fix RGB channel order in the rgb2luv conversion

### DIFF
--- a/modules/ximgproc/src/structured_edge_detection.cpp
+++ b/modules/ximgproc/src/structured_edge_detection.cpp
@@ -152,7 +152,7 @@ static cv::Mat rgb2luv(const cv::Mat &src)
 
         for (int j = 0; j < src.cols*nchannels; j += nchannels)
         {
-            const float rgb[] = {pSrc[j + 0], pSrc[j + 1], pSrc[j + 2]};
+            const float rgb[] = {pSrc[j + 2], pSrc[j + 1], pSrc[j + 0]};
 
             const float xyz[] = {mX[0]*rgb[0] + mX[1]*rgb[1] + mX[2]*rgb[2],
                                  mY[0]*rgb[0] + mY[1]*rgb[1] + mY[2]*rgb[2],


### PR DESCRIPTION
In the current rgb2luv() function, rgb[0], rgb[1], and rgb[2] are used as B,G, and R channel, respectively. This is not right. For the RGB to LUV color space conversion in the code, rgb[0], rgb[2] is should be R, B, respectively. This change simply fixes the problem by exchanging the position of R and B (recall that OpenCV's RGB channel order is BGR).